### PR TITLE
Add a default phpunit.dist.xml

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>


### PR DESCRIPTION
This way it's enough to run `vendor/bin/phpunit` and doesn't require
specifying the tests director explicitly anymore.

It's also some kind of good practice to provide a `.dist.xml` (if desired, the developer can use a different `.xml` instead).