### PR TITLE
Reformat whole code base to unify code style   to PSR1/PSR2

### DIFF
--- a/src/Examples/CSVParser.php
+++ b/src/Examples/CSVParser.php
@@ -33,13 +33,13 @@ class CSVParser extends \ParserGenerator\Parser
 
         if ($csvRaw) {
             $data = array();
-            foreach($csvRaw->getSubnode(0)->getMainNodes() as $csvLine) {
+            foreach ($csvRaw->getSubnode(0)->getMainNodes() as $csvLine) {
                 $line = array();
-                foreach($csvLine->getSubnode(0)->getMainNodes() as $csvValue) {
+                foreach ($csvLine->getSubnode(0)->getMainNodes() as $csvValue) {
                     if ($csvValue->getDetailType() == 0) {
                         $line[] = $csvValue->getSubnode(1)->getValue();
                     } else {
-                        $line[] = (string) $csvValue;
+                        $line[] = (string)$csvValue;
                     }
                 }
 

--- a/src/Examples/JSONFormater.php
+++ b/src/Examples/JSONFormater.php
@@ -4,11 +4,14 @@ namespace ParserGenerator\Examples;
 
 class JSONFormater extends \ParserGenerator\Parser
 {
-    public function __construct() {
-        parent::__construct($this->getJSONDefinition(), array('ignoreWhitespaces' => true, 'defaultBranchType' => 'PEG'));
+    public function __construct()
+    {
+        parent::__construct($this->getJSONDefinition(),
+            array('ignoreWhitespaces' => true, 'defaultBranchType' => 'PEG'));
     }
 
-    protected function getJSONDefinition() {
+    protected function getJSONDefinition()
+    {
         return '
         start:       => value.
         value:bool   => ("true"|"false")
@@ -21,16 +24,18 @@ class JSONFormater extends \ParserGenerator\Parser
         ';
     }
 
-    public function setObjectsPropertiesOrder($node) {
+    public function setObjectsPropertiesOrder($node)
+    {
         $node->inPlaceTranslate('value:object', function ($node) {
             $node->getSubnode(1)->orderBy('key');
         });
     }
 
-    public function setIndention($node, $indention = '    ', $start = "\n") {
+    public function setIndention($node, $indention = '    ', $start = "\n")
+    {
         if ($node->getType() === 'start') {
-            foreach($node->getLeafs() as $leaf) {
-                $leaf->setAfterContent((string) $leaf == ':' ? ' ' : '');
+            foreach ($node->getLeafs() as $leaf) {
+                $leaf->setAfterContent((string)$leaf == ':' ? ' ' : '');
             }
 
             return $this->setIndention($node->getSubnode(0), $indention, $start);
@@ -43,13 +48,13 @@ class JSONFormater extends \ParserGenerator\Parser
 
             $collection = $node->getSubnode(1);
 
-            foreach($collection->getSeparators() as $separator) {
+            foreach ($collection->getSeparators() as $separator) {
                 $separator->setAfterContent($start . $indention);
             }
 
             $collection->setAfterContent($start);
 
-            foreach($collection->getMainNodes() as $collectionNode) {
+            foreach ($collection->getMainNodes() as $collectionNode) {
                 if ($node->getDetailType() === 'array') {
                     $this->setIndention($collectionNode, $indention, $start . $indention);
                 } else {

--- a/src/Examples/JSONParser.php
+++ b/src/Examples/JSONParser.php
@@ -4,11 +4,13 @@ namespace ParserGenerator\Examples;
 
 class JSONParser extends \ParserGenerator\Parser
 {
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct($this->getJSONDefinition(), array('ignoreWhitespaces' => true));
     }
 
-    protected function getJSONDefinition() {
+    protected function getJSONDefinition()
+    {
         return '
         start:       => value.
         value:bool   => ("true"|"false")
@@ -20,7 +22,8 @@ class JSONParser extends \ParserGenerator\Parser
         ';
     }
 
-    public function getValue($jsonString) {
+    public function getValue($jsonString)
+    {
         $jsonTree = $this->parse($jsonString);
 
         if (!$jsonTree) {
@@ -30,17 +33,18 @@ class JSONParser extends \ParserGenerator\Parser
         return $this->getValueOfNode($jsonTree->getSubnode(0));
     }
 
-    protected function getValueOfNode(\ParserGenerator\SyntaxTreeNode\Branch $node) {
+    protected function getValueOfNode(\ParserGenerator\SyntaxTreeNode\Branch $node)
+    {
         switch ($node->getDetailType()) {
             case "bool":
-                return (string) $node === "true";
+                return (string)$node === "true";
             case "string":
             case "number":
                 return $node->getSubnode(0)->getValue();
             case "array":
                 $result = array();
 
-                foreach($node->getSubnode(1)->getMainNodes() as $valueNode) {
+                foreach ($node->getSubnode(1)->getMainNodes() as $valueNode) {
                     $result[] = $this->getValueOfNode($valueNode);
                 }
 
@@ -48,7 +52,7 @@ class JSONParser extends \ParserGenerator\Parser
             case "object":
                 $result = array();
 
-                foreach($node->getSubnode(1)->getMainNodes() as $objValueNode) {
+                foreach ($node->getSubnode(1)->getMainNodes() as $objValueNode) {
                     $result[$objValueNode->getSubnode(0)->getValue()] = $this->getValueOfNode($objValueNode->getSubnode(2));
                 }
 

--- a/src/Examples/YamlLikeIndentationParser.php
+++ b/src/Examples/YamlLikeIndentationParser.php
@@ -8,11 +8,13 @@ namespace ParserGenerator\Examples;
  */
 class YamlLikeIndentationParser extends \ParserGenerator\Parser
 {
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct($this->getYamlDefinition());
     }
 
-    protected function getYamlDefinition() {
+    protected function getYamlDefinition()
+    {
         return '
         start            :       => value<""> nl?.
         value<indent>    :string => space* simpleString
@@ -26,7 +28,8 @@ class YamlLikeIndentationParser extends \ParserGenerator\Parser
         ';
     }
 
-    public function getValue($yamlString) {
+    public function getValue($yamlString)
+    {
         $yamlTree = $this->parse($yamlString);
 
         if (!$yamlTree) {
@@ -36,15 +39,16 @@ class YamlLikeIndentationParser extends \ParserGenerator\Parser
         return $this->getValueOfNode($yamlTree->getSubnode(0));
     }
 
-    protected function getValueOfNode(\ParserGenerator\SyntaxTreeNode\Branch $node) {
+    protected function getValueOfNode(\ParserGenerator\SyntaxTreeNode\Branch $node)
+    {
         if ($node->getType() == 'value' && $node->getDetailType() == 'string') {
-            return (string) $node->getSubnode(1);
+            return (string)$node->getSubnode(1);
         } elseif ($node->getType() == 'value' && $node->getDetailType() == 'object') {
             return $this->getValueOfNode($node->getSubnode(0));
         } elseif ($node->getType() == 'objValues' && $node->getDetailType() == 'values') {
             $result = array();
-            foreach($node->getSubnode(0)->getMainNodes() as $objValue) {
-                $result[(string) $objValue->getSubnode(2)] = $this->getValueOfNode($objValue->getSubnode(5));
+            foreach ($node->getSubnode(0)->getMainNodes() as $objValue) {
+                $result[(string)$objValue->getSubnode(2)] = $this->getValueOfNode($objValue->getSubnode(5));
             }
             return $result;
         } elseif ($node->getType() == 'objValues' && $node->getDetailType() == 'indent') {

--- a/src/Extension/Choice.php
+++ b/src/Extension/Choice.php
@@ -41,18 +41,17 @@ class Choice extends \ParserGenerator\Extension\SequenceItem
 
         return $node;
     }
-	
-	private function buildInternalSequence(&$grammar, $sequence, $grammarParser, $options)
-	{
-	    $choice = array();
-		
-		foreach($sequence->findAll('sequenceItem') as $sequenceItem)
-		{
-		    $choice[] = $grammarParser->buildSequenceItem($grammar, $sequenceItem, $options);
-		}
-		
-		return (count($choice) === 1) ? $choice[0] : $choice;
-	}
+
+    private function buildInternalSequence(&$grammar, $sequence, $grammarParser, $options)
+    {
+        $choice = array();
+
+        foreach ($sequence->findAll('sequenceItem') as $sequenceItem) {
+            $choice[] = $grammarParser->buildSequenceItem($grammar, $sequenceItem, $options);
+        }
+
+        return (count($choice) === 1) ? $choice[0] : $choice;
+    }
 }
 
 \ParserGenerator\GrammarParser::$defaultPlugins[] = new Choice();

--- a/src/Extension/Integer.php
+++ b/src/Extension/Integer.php
@@ -8,23 +8,37 @@ class Integer extends \ParserGenerator\Extension\SequenceItem
 
     public function extendGrammar($grammarGrammar)
     {
-        $grammarGrammar[$this->getNS(null, false)] = array(array(
-            $this->getNS('LowBound'),
-            new \ParserGenerator\GrammarNode\Text('..'),
-            $this->getNS('HiBound'),
-            $this->getNs('modifiers'),
-            ''
-        ));
+        $grammarGrammar[$this->getNS(null, false)] = array(
+            array(
+                $this->getNS('LowBound'),
+                new \ParserGenerator\GrammarNode\Text('..'),
+                $this->getNS('HiBound'),
+                $this->getNs('modifiers'),
+                ''
+            )
+        );
 
         $grammarGrammar[$this->getNS('LowBound', false)] = array(
             array(new \ParserGenerator\GrammarNode\Text('-inf')),
             array(new \ParserGenerator\GrammarNode\Text('-infinity')),
-            'int' => array(new \ParserGenerator\GrammarNode\Numeric(array('formatHex' => true, 'formatBin' => true, 'allowFixedCharacters' => true)))
+            'int' => array(
+                new \ParserGenerator\GrammarNode\Numeric(array(
+                    'formatHex' => true,
+                    'formatBin' => true,
+                    'allowFixedCharacters' => true
+                ))
+            )
         );
         $grammarGrammar[$this->getNS('HiBound', false)] = array(
             array(new \ParserGenerator\GrammarNode\Text('inf')),
             array(new \ParserGenerator\GrammarNode\Text('infinity')),
-            'int' => array(new \ParserGenerator\GrammarNode\Numeric(array('formatHex' => true, 'formatBin' => true, 'allowFixedCharacters' => true)))
+            'int' => array(
+                new \ParserGenerator\GrammarNode\Numeric(array(
+                    'formatHex' => true,
+                    'formatBin' => true,
+                    'allowFixedCharacters' => true
+                ))
+            )
         );
 
         $grammarGrammar[$this->getNS('modifiers', false)] = array(

--- a/src/Extension/ItemRestrictions.php
+++ b/src/Extension/ItemRestrictions.php
@@ -9,11 +9,11 @@ require_once('ItemRestrictions/ItemRestrictionNot.php');
 require_once('ItemRestrictions/Contain.php');
 require_once('ItemRestrictions/Is.php');
 
-use ParserGenerator\Extension\ItemRestrictions\ItemRestrictionOr;
-use ParserGenerator\Extension\ItemRestrictions\ItemRestrictionAnd;
-use ParserGenerator\Extension\ItemRestrictions\ItemRestrictionNot;
 use ParserGenerator\Extension\ItemRestrictions\Contain;
 use ParserGenerator\Extension\ItemRestrictions\Is;
+use ParserGenerator\Extension\ItemRestrictions\ItemRestrictionAnd;
+use ParserGenerator\Extension\ItemRestrictions\ItemRestrictionNot;
+use ParserGenerator\Extension\ItemRestrictions\ItemRestrictionOr;
 
 
 class ItemRestrictions extends \ParserGenerator\Extension\SequenceItem
@@ -27,27 +27,29 @@ class ItemRestrictions extends \ParserGenerator\Extension\SequenceItem
 
     public function extendGrammar($grammarGrammar)
     {
-        $grammarGrammar[$this->getNS('', false)] = array(array(
-            ':sequenceItem',
-		    $this->getNS('condition')
-        ));
+        $grammarGrammar[$this->getNS('', false)] = array(
+            array(
+                ':sequenceItem',
+                $this->getNS('condition')
+            )
+        );
 
         $grammarGrammar[$this->getNS('condition', false)] = array(
-		    array($this->getNS('conditionAnd'), 'or', $this->getNS('condition')),
-			'last' => array($this->getNS('conditionAnd'))
-		);
-		
-		$grammarGrammar[$this->getNS('conditionAnd', false)] = array(
-		    array($this->getNS('simpleCondition'), 'and', $this->getNS('conditionAnd')),
-			'last' => array($this->getNS('simpleCondition'))
-		);
-		
-		$grammarGrammar[$this->getNS('simpleCondition', false)] = array(
-		    'bracket' => array('(', $this->getNS('condition'), ':comments', ')'),
-			'not' => array('not', $this->getNS('simpleCondition')),
-			'contain' => array('contain', ':sequenceItem'),
-			'is' => array('is', ':sequenceItem')
-		);
+            array($this->getNS('conditionAnd'), 'or', $this->getNS('condition')),
+            'last' => array($this->getNS('conditionAnd'))
+        );
+
+        $grammarGrammar[$this->getNS('conditionAnd', false)] = array(
+            array($this->getNS('simpleCondition'), 'and', $this->getNS('conditionAnd')),
+            'last' => array($this->getNS('simpleCondition'))
+        );
+
+        $grammarGrammar[$this->getNS('simpleCondition', false)] = array(
+            'bracket' => array('(', $this->getNS('condition'), ':comments', ')'),
+            'not' => array('not', $this->getNS('simpleCondition')),
+            'contain' => array('contain', ':sequenceItem'),
+            'is' => array('is', ':sequenceItem')
+        );
 
         return parent::extendGrammar($grammarGrammar);
     }
@@ -64,53 +66,60 @@ class ItemRestrictions extends \ParserGenerator\Extension\SequenceItem
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
-	    $this->itemBuilderCallback = function ($sequenceItem) use (&$grammar, $grammarParser, $options) {
-		    return $grammarParser->buildSequenceItem($grammar, $sequenceItem, $options);
-		};
+        $this->itemBuilderCallback = function ($sequenceItem) use (&$grammar, $grammarParser, $options) {
+            return $grammarParser->buildSequenceItem($grammar, $sequenceItem, $options);
+        };
 
-	    $grammarNode = $grammarParser->buildSequenceItem($grammar, $sequenceItem->getSubnode(0)->getSubnode(0), $options);
-		$condition = $this->buildCondition($sequenceItem->getSubnode(0)->getSubnode(1));
-		
+        $grammarNode = $grammarParser->buildSequenceItem($grammar, $sequenceItem->getSubnode(0)->getSubnode(0),
+            $options);
+        $condition = $this->buildCondition($sequenceItem->getSubnode(0)->getSubnode(1));
+
         return new \ParserGenerator\GrammarNode\ItemRestrictions($grammarNode, $condition);
     }
-	
-	protected function buildCondition($node)
-	{
-	    switch ($node->getType()) {
-		    case $this->getNS('condition', false):
-			    if ($node->getDetailType() === 'last') {
-				    return $this->buildCondition($node->getSubnode(0));
-				} else {
-				    return new ItemRestrictionOr(array($this->buildCondition($node->getSubnode(0)), $this->buildCondition($node->getSubnode(2))));
-				}
-				
-		    case $this->getNS('conditionAnd', false):
-			    if ($node->getDetailType() === 'last') {
-				    return $this->buildCondition($node->getSubnode(0));
-				} else {
-				    return new ItemRestrictionAnd(array($this->buildCondition($node->getSubnode(0)), $this->buildCondition($node->getSubnode(2))));
-				}
-				
-		    case $this->getNS('simpleCondition', false):
-			    switch ($node->getDetailType()) {
-				    case 'bracket':
-					    return $this->buildCondition($node->getSubnode(1));
-						
-				    case 'not':
-					    return new ItemRestrictionNot($this->buildCondition($node->getSubnode(1)));
-						
-				    case 'contain':
-					    $itemBuilder = $this->itemBuilderCallback;
-					
-					    return new Contain($itemBuilder($node->getSubnode(1)));
-						
-				    case 'is':
-					    $itemBuilder = $this->itemBuilderCallback;
-					
-					    return new Is($itemBuilder($node->getSubnode(1)));
-				}
-		}
-	}
+
+    protected function buildCondition($node)
+    {
+        switch ($node->getType()) {
+            case $this->getNS('condition', false):
+                if ($node->getDetailType() === 'last') {
+                    return $this->buildCondition($node->getSubnode(0));
+                } else {
+                    return new ItemRestrictionOr(array(
+                        $this->buildCondition($node->getSubnode(0)),
+                        $this->buildCondition($node->getSubnode(2))
+                    ));
+                }
+
+            case $this->getNS('conditionAnd', false):
+                if ($node->getDetailType() === 'last') {
+                    return $this->buildCondition($node->getSubnode(0));
+                } else {
+                    return new ItemRestrictionAnd(array(
+                        $this->buildCondition($node->getSubnode(0)),
+                        $this->buildCondition($node->getSubnode(2))
+                    ));
+                }
+
+            case $this->getNS('simpleCondition', false):
+                switch ($node->getDetailType()) {
+                    case 'bracket':
+                        return $this->buildCondition($node->getSubnode(1));
+
+                    case 'not':
+                        return new ItemRestrictionNot($this->buildCondition($node->getSubnode(1)));
+
+                    case 'contain':
+                        $itemBuilder = $this->itemBuilderCallback;
+
+                        return new Contain($itemBuilder($node->getSubnode(1)));
+
+                    case 'is':
+                        $itemBuilder = $this->itemBuilderCallback;
+
+                        return new Is($itemBuilder($node->getSubnode(1)));
+                }
+        }
+    }
 }
 
 \ParserGenerator\GrammarParser::$defaultPlugins[] = new ItemRestrictions();

--- a/src/Extension/ItemRestrictions/Contain.php
+++ b/src/Extension/ItemRestrictions/Contain.php
@@ -5,32 +5,32 @@ namespace ParserGenerator\Extension\ItemRestrictions;
 class Contain implements \ParserGenerator\Extension\ItemRestrictions\ItemRestrictionInterface
 {
     protected $grammarNode;
-	
-	public function __construct($grammarNode)
-	{
-	    $this->grammarNode = $grammarNode;
-	}
-	
-	public function check($string, $fromIndex, $toIndex, $node)
-	{
-	    for ($currentIndex = $fromIndex; $currentIndex < $toIndex; $currentIndex++) {
-		    $restrictedEnds = array();
-			while (true) {
-			    $parsedNode = $this->grammarNode->rparse($string, $currentIndex, $restrictedEnds);
-				
-				if (!$parsedNode) {
-				    break;
-				}
-				
-				$offset = $parsedNode['offset'] - strlen($parsedNode['node']->getRightLeaf()->getAfterContent());
-				if ($offset > $toIndex) {
+
+    public function __construct($grammarNode)
+    {
+        $this->grammarNode = $grammarNode;
+    }
+
+    public function check($string, $fromIndex, $toIndex, $node)
+    {
+        for ($currentIndex = $fromIndex; $currentIndex < $toIndex; $currentIndex++) {
+            $restrictedEnds = array();
+            while (true) {
+                $parsedNode = $this->grammarNode->rparse($string, $currentIndex, $restrictedEnds);
+
+                if (!$parsedNode) {
+                    break;
+                }
+
+                $offset = $parsedNode['offset'] - strlen($parsedNode['node']->getRightLeaf()->getAfterContent());
+                if ($offset > $toIndex) {
                     $restrictedEnds[$offset] = $offset;
                 } else {
-				    return true;
-				}
-			}
-		}
-		
-		return false;
-	}
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Extension/ItemRestrictions/FollowedBy.php
+++ b/src/Extension/ItemRestrictions/FollowedBy.php
@@ -5,14 +5,14 @@ namespace ParserGenerator\Extension\ItemRestrictions;
 class FollowedBy implements \ParserGenerator\Extension\ItemRestrictions\ItemRestrictionInterface
 {
     protected $grammarNode;
-	
-	public function __construct($grammarNode)
-	{
-	    $this->grammarNode = $grammarNode;
-	}
-	
-	public function check($string, $fromIndex, $toIndex, $node)
-	{
-	    return (bool) $this->grammarNode->rparse($string, $toIndex, array()); 
-	}
+
+    public function __construct($grammarNode)
+    {
+        $this->grammarNode = $grammarNode;
+    }
+
+    public function check($string, $fromIndex, $toIndex, $node)
+    {
+        return (bool)$this->grammarNode->rparse($string, $toIndex, array());
+    }
 }

--- a/src/Extension/ItemRestrictions/Is.php
+++ b/src/Extension/ItemRestrictions/Is.php
@@ -5,25 +5,25 @@ namespace ParserGenerator\Extension\ItemRestrictions;
 class Is implements \ParserGenerator\Extension\ItemRestrictions\ItemRestrictionInterface
 {
     protected $grammarNode;
-	
-	public function __construct($grammarNode)
-	{
-	    $this->grammarNode = $grammarNode;
-	}
-	
-	public function check($string, $fromIndex, $toIndex, $node)
-	{
-		$restrictedEnds = array();
-		while (true) {
-			$parsedNode = $this->grammarNode->rparse($string, $fromIndex, $restrictedEnds);
-				
-			if (!$parsedNode) {
-			    return false;
-			} elseif ($parsedNode['offset'] === $toIndex) {
-			    return true;
-			} else {
-			    $restrictedEnds[$parsedNode['offset']] = $parsedNode['offset'];
-			}
-	    }
-	}
+
+    public function __construct($grammarNode)
+    {
+        $this->grammarNode = $grammarNode;
+    }
+
+    public function check($string, $fromIndex, $toIndex, $node)
+    {
+        $restrictedEnds = array();
+        while (true) {
+            $parsedNode = $this->grammarNode->rparse($string, $fromIndex, $restrictedEnds);
+
+            if (!$parsedNode) {
+                return false;
+            } elseif ($parsedNode['offset'] === $toIndex) {
+                return true;
+            } else {
+                $restrictedEnds[$parsedNode['offset']] = $parsedNode['offset'];
+            }
+        }
+    }
 }

--- a/src/Extension/ItemRestrictions/ItemRestrictionAnd.php
+++ b/src/Extension/ItemRestrictions/ItemRestrictionAnd.php
@@ -5,20 +5,20 @@ namespace ParserGenerator\Extension\ItemRestrictions;
 class ItemRestrictionAnd implements \ParserGenerator\Extension\ItemRestrictions\ItemRestrictionInterface
 {
     protected $children;
-	
-	public function __construct($children)
-	{
-	    $this->children = $children;
-	}
-	
-	public function check($string, $fromIndex, $toIndex, $node)
-	{
-	    foreach($this->children as $child) {
-		    if (!$child->check($string, $fromIndex, $toIndex, $node)) {
-			    return false;
-			}
-		}
-		
-		return true;
-	}
+
+    public function __construct($children)
+    {
+        $this->children = $children;
+    }
+
+    public function check($string, $fromIndex, $toIndex, $node)
+    {
+        foreach ($this->children as $child) {
+            if (!$child->check($string, $fromIndex, $toIndex, $node)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Extension/ItemRestrictions/ItemRestrictionNot.php
+++ b/src/Extension/ItemRestrictions/ItemRestrictionNot.php
@@ -5,14 +5,14 @@ namespace ParserGenerator\Extension\ItemRestrictions;
 class ItemRestrictionNot implements \ParserGenerator\Extension\ItemRestrictions\ItemRestrictionInterface
 {
     protected $child;
-	
-	public function __construct($child)
-	{
-	    $this->child = $child;
-	}
-	
-	public function check($string, $fromIndex, $toIndex, $node)
-	{
-	    return !$this->child->check($string, $fromIndex, $toIndex, $node);
-	}
+
+    public function __construct($child)
+    {
+        $this->child = $child;
+    }
+
+    public function check($string, $fromIndex, $toIndex, $node)
+    {
+        return !$this->child->check($string, $fromIndex, $toIndex, $node);
+    }
 }

--- a/src/Extension/ItemRestrictions/ItemRestrictionOr.php
+++ b/src/Extension/ItemRestrictions/ItemRestrictionOr.php
@@ -5,20 +5,20 @@ namespace ParserGenerator\Extension\ItemRestrictions;
 class ItemRestrictionOr implements \ParserGenerator\Extension\ItemRestrictions\ItemRestrictionInterface
 {
     protected $children;
-	
-	public function __construct($children)
-	{
-	    $this->children = $children;
-	}
-	
-	public function check($string, $fromIndex, $toIndex, $node)
-	{
-	    foreach($this->children as $child) {
-		    if ($child->check($string, $fromIndex, $toIndex, $node)) {
-			    return true;
-			}
-		}
-		
-		return false;
-	}
+
+    public function __construct($children)
+    {
+        $this->children = $children;
+    }
+
+    public function check($string, $fromIndex, $toIndex, $node)
+    {
+        foreach ($this->children as $child) {
+            if ($child->check($string, $fromIndex, $toIndex, $node)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Extension/ParametrizedNode.php
+++ b/src/Extension/ParametrizedNode.php
@@ -14,7 +14,8 @@ class ParametrizedNode extends Base
     {
         $this->nodeParams = array();
 
-        $grammarGrammar['grammarBranch']['standard'] = $this->insert($grammarGrammar['grammarBranch']['standard'], ':branchName', ':branchParamsDef');
+        $grammarGrammar['grammarBranch']['standard'] = $this->insert($grammarGrammar['grammarBranch']['standard'],
+            ':branchName', ':branchParamsDef');
 
         $grammarGrammar['branchParamsDef'] = array(
             array('<', ':branchParamsDefList', '>'),
@@ -26,7 +27,12 @@ class ParametrizedNode extends Base
             'notLast' => array(':branchName', ',', ':branchParamsDefList')
         );
 
-        $grammarGrammar['sequenceItem']['parametrizedNode'] = array(':branchName', '<', ':parametrizedNodeParamsList', '>');
+        $grammarGrammar['sequenceItem']['parametrizedNode'] = array(
+            ':branchName',
+            '<',
+            ':parametrizedNodeParamsList',
+            '>'
+        );
         $grammarGrammar['parametrizedNodeParamsList'] = array(
             'last' => array(':sequenceItem'),
             'notLast' => array(':sequenceItem', ',', ':parametrizedNodeParamsList')
@@ -37,11 +43,11 @@ class ParametrizedNode extends Base
 
     public function modifyBranches($grammar, $parsedGrammar, $grammarParser, $options)
     {
-        foreach($parsedGrammar->findAll('grammarBranch:standard') as $grammarBranch) {
-            $name = (string) $grammarBranch->findFirst('branchName');
+        foreach ($parsedGrammar->findAll('grammarBranch:standard') as $grammarBranch) {
+            $name = (string)$grammarBranch->findFirst('branchName');
             $i = 0;
-            foreach($grammarBranch->findFirst('branchParamsDef')->findAll('branchName') as $branchName) {
-                $this->nodeParams[$name][(string) $branchName] = new ParameterNode($i++, $name, (string) $branchName);
+            foreach ($grammarBranch->findFirst('branchParamsDef')->findAll('branchName') as $branchName) {
+                $this->nodeParams[$name][(string)$branchName] = new ParameterNode($i++, $name, (string)$branchName);
             }
         }
 
@@ -52,20 +58,20 @@ class ParametrizedNode extends Base
     {
         if ($sequenceItem->getDetailType() === 'branch') {
             $branchNode = $sequenceItem->nearestOwner('grammarBranch:standard');
-            $branchName = $branchNode ? (string) $branchNode->findFirst('branchName') : null;
-            if ($branchNode && isset($this->nodeParams[$branchName][(string) $sequenceItem])) {
-                return $this->nodeParams[$branchName][(string) $sequenceItem];
+            $branchName = $branchNode ? (string)$branchNode->findFirst('branchName') : null;
+            if ($branchNode && isset($this->nodeParams[$branchName][(string)$sequenceItem])) {
+                return $this->nodeParams[$branchName][(string)$sequenceItem];
             }
             return null;
         }
 
         if ($sequenceItem->getDetailType() === 'parametrizedNode') {
             $params = array();
-            foreach($sequenceItem->findFirst('parametrizedNodeParamsList')->findAll('sequenceItem') as $param) {
+            foreach ($sequenceItem->findFirst('parametrizedNodeParamsList')->findAll('sequenceItem') as $param) {
                 $params[] = $grammarParser->buildSequenceItem($grammar, $param, $options);
             }
 
-            $node = new GrammarNode($grammar[(string) $sequenceItem->findFirst('branchName')], $params);
+            $node = new GrammarNode($grammar[(string)$sequenceItem->findFirst('branchName')], $params);
             $node->setParser($options['parser']);
             return $node;
         }

--- a/src/Extension/Regex.php
+++ b/src/Extension/Regex.php
@@ -11,7 +11,8 @@ class Regex extends \ParserGenerator\Extension\SequenceItem
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
-        return new \ParserGenerator\GrammarNode\Regex((string)$sequenceItem, !empty($options['ignoreWhitespaces']), !empty($options['caseInsensitive']));
+        return new \ParserGenerator\GrammarNode\Regex((string)$sequenceItem, !empty($options['ignoreWhitespaces']),
+            !empty($options['caseInsensitive']));
     }
 }
 

--- a/src/Extension/RuleCondition.php
+++ b/src/Extension/RuleCondition.php
@@ -18,7 +18,7 @@ class RuleCondition extends \ParserGenerator\Extension\Base
         foreach ($parsedGrammar->findAll('grammarBranch') as $grammarBranch) {
             $functions = array();
             foreach ($grammarBranch->findAll('rule') as $ruleIndex => $rule) {
-                $ruleName = (string)$rule->findFirst('ruleName') ? : $ruleIndex;
+                $ruleName = (string)$rule->findFirst('ruleName') ?: $ruleIndex;
                 if ($condition = $rule->findFirst('ruleCondition')) {
                     $functions[$ruleName] = (string)$condition->getSubnode(1);
                 }
@@ -26,7 +26,8 @@ class RuleCondition extends \ParserGenerator\Extension\Base
 
             if (count($functions)) {
                 $branchName = (string)$grammarBranch->findFirst('branchName');
-                $grammar[$branchName] = new \ParserGenerator\GrammarNode\BranchStringCondition($grammar[$branchName], $functions);
+                $grammar[$branchName] = new \ParserGenerator\GrammarNode\BranchStringCondition($grammar[$branchName],
+                    $functions);
             }
         }
 

--- a/src/Extension/Series.php
+++ b/src/Extension/Series.php
@@ -36,19 +36,20 @@ class Series extends \ParserGenerator\Extension\SequenceItem
             case '+':
             case '*':
                 $greedy = in_array($operator, array('**', '++')) || $forceGreedy;
-                $node = new \ParserGenerator\GrammarNode\Series($main, $separator, in_array($operator, array('*', '**')), $greedy);
+                $node = new \ParserGenerator\GrammarNode\Series($main, $separator,
+                    in_array($operator, array('*', '**')), $greedy);
                 if (isset($options['parser'])) {
                     $node->setParser($options['parser']);
                 }
 
                 return $node;
-			case '??':
-			case '?':
-			    $empty = new \ParserGenerator\GrammarNode\Text('');
-				$choices = ($operator == '??' || $forceGreedy) ? array($main, $empty) : array($empty, $main);
-			    $node = new \ParserGenerator\GrammarNode\Choice($choices);
-				
-				if (isset($options['parser'])) {
+            case '??':
+            case '?':
+                $empty = new \ParserGenerator\GrammarNode\Text('');
+                $choices = ($operator == '??' || $forceGreedy) ? array($main, $empty) : array($empty, $main);
+                $node = new \ParserGenerator\GrammarNode\Choice($choices);
+
+                if (isset($options['parser'])) {
                     $node->setParser($options['parser']);
                 }
 

--- a/src/Extension/StringObject.php
+++ b/src/Extension/StringObject.php
@@ -14,17 +14,20 @@ class StringObject extends \ParserGenerator\Extension\SequenceItem
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
-        $type = $sequenceItem->getSubnode(1) ? (string) $sequenceItem->getSubnode(1) : 'default';
+        $type = $sequenceItem->getSubnode(1) ? (string)$sequenceItem->getSubnode(1) : 'default';
 
         switch ($type) {
             case "default":
-                return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']), array("'", '"'));
+                return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']),
+                    array("'", '"'));
 
             case "apostrophe":
-                return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']), array("'"));
+                return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']),
+                    array("'"));
 
             case "quotation":
-                return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']), array('"'));
+                return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']),
+                    array('"'));
 
             case "simple":
                 return new \ParserGenerator\GrammarNode\PredefinedSimpleString(!empty($options['ignoreWhitespaces']));

--- a/src/Extension/Text.php
+++ b/src/Extension/Text.php
@@ -7,15 +7,17 @@ class Text extends \ParserGenerator\Extension\SequenceItem
     const _NAMESPACE = 'TextPlugin';
 
     public function extendGrammar($grammarGrammar)
-	{
-	    $grammarGrammar[$this->getNS(null, false)] = array(array(
-            'text',
-        ));
-		
-		return parent::extendGrammar($grammarGrammar);
-	}
-	
-	protected function getNS($node = '', $addColon = true)
+    {
+        $grammarGrammar[$this->getNS(null, false)] = array(
+            array(
+                'text',
+            )
+        );
+
+        return parent::extendGrammar($grammarGrammar);
+    }
+
+    protected function getNS($node = '', $addColon = true)
     {
         return ($addColon ? ':' : '') . static::_NAMESPACE . ($node ? '_' . $node : '');
     }
@@ -24,11 +26,11 @@ class Text extends \ParserGenerator\Extension\SequenceItem
     {
         return array($this->getNS(''));
     }
-	
-	protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
+
+    protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
-	    return new \ParserGenerator\GrammarNode\AnyText($options);
-	}
+        return new \ParserGenerator\GrammarNode\AnyText($options);
+    }
 }
 
 \ParserGenerator\GrammarParser::$defaultPlugins[] = new Text();

--- a/src/Extension/TextNode.php
+++ b/src/Extension/TextNode.php
@@ -12,9 +12,10 @@ class TextNode extends \ParserGenerator\Extension\SequenceItem
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
         if (!empty($options['caseInsensitive'])) {
-		    $regex = \ParserGenerator\RegexUtil::buildRegexFromString((string)$sequenceItem->getSubnode(0)->getValue());
-            return new \ParserGenerator\GrammarNode\Regex($regex, !empty($options['ignoreWhitespaces']), !empty($options['caseInsensitive']));
-		} elseif (empty($options['ignoreWhitespaces'])) {
+            $regex = \ParserGenerator\RegexUtil::buildRegexFromString((string)$sequenceItem->getSubnode(0)->getValue());
+            return new \ParserGenerator\GrammarNode\Regex($regex, !empty($options['ignoreWhitespaces']),
+                !empty($options['caseInsensitive']));
+        } elseif (empty($options['ignoreWhitespaces'])) {
             return new \ParserGenerator\GrammarNode\Text($sequenceItem->getSubnode(0)->getValue());
         } else {
             return new \ParserGenerator\GrammarNode\TextS($sequenceItem->getSubnode(0)->getValue());

--- a/src/Extension/Time.php
+++ b/src/Extension/Time.php
@@ -8,7 +8,7 @@
 
 namespace ParserGenerator\Extension;
 
-use \ParserGenerator\GrammarNode\LeafTime;
+use ParserGenerator\GrammarNode\LeafTime;
 
 class Time extends \ParserGenerator\Extension\SequenceItem
 {
@@ -21,7 +21,7 @@ class Time extends \ParserGenerator\Extension\SequenceItem
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
-        return new LeafTime((string) $sequenceItem->getSubnode(1), !empty($options['ignoreWhitespaces']));
+        return new LeafTime((string)$sequenceItem->getSubnode(1), !empty($options['ignoreWhitespaces']));
     }
 }
 

--- a/src/Extension/Unorder.php
+++ b/src/Extension/Unorder.php
@@ -29,7 +29,7 @@ class Unorder extends \ParserGenerator\Extension\SequenceItem
 
         while ($sequenceNode) {
             $n = $this->buildInternalSequence($grammar, $sequenceNode->getSubnode(1), $grammarParser, $options);
-            $node->addChoice($n, (string) $sequenceNode->getSubnode(0));
+            $node->addChoice($n, (string)$sequenceNode->getSubnode(0));
             $sequenceNode = ($sequenceNode->getDetailType() == 'last') ? null : $sequenceNode->getSubnode(3);
         }
 
@@ -47,8 +47,7 @@ class Unorder extends \ParserGenerator\Extension\SequenceItem
     {
         $choice = array();
 
-        foreach($sequence->findAll('sequenceItem') as $sequenceItem)
-        {
+        foreach ($sequence->findAll('sequenceItem') as $sequenceItem) {
             $choice[] = $grammarParser->buildSequenceItem($grammar, $sequenceItem, $options);
         }
 

--- a/src/GrammarNode/AnyText.php
+++ b/src/GrammarNode/AnyText.php
@@ -8,42 +8,45 @@ class AnyText extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
     public $ignoreWhitespaces;
 
     public function __construct($options = array())
-	{
-	    $this->ignoreWhitespaces = true;
-	}
+    {
+        $this->ignoreWhitespaces = true;
+    }
 
     public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
     {
-	    $endPos = $this->getNextNonrestrictedIndex($string, $fromIndex, $restrictedEnd);
-		$str = substr($string, $fromIndex, $endPos - $fromIndex);
-		
-		if ($endPos !== null) {
-		    if ($this->ignoreWhitespaces) {
-			    $trimedString = rtrim($str);
-				$whitespaces = substr($str, strlen($trimedString));
-			    return array('node' => new \ParserGenerator\SyntaxTreeNode\Leaf($trimedString, $whitespaces), 'offset' => $endPos);
-			} else {
-			    return array('node' => new \ParserGenerator\SyntaxTreeNode\Leaf($str), 'offset' => $endPos);
-			}
-		} else {
-		    return false;
-		}
-	}
-	
+        $endPos = $this->getNextNonrestrictedIndex($string, $fromIndex, $restrictedEnd);
+        $str = substr($string, $fromIndex, $endPos - $fromIndex);
+
+        if ($endPos !== null) {
+            if ($this->ignoreWhitespaces) {
+                $trimedString = rtrim($str);
+                $whitespaces = substr($str, strlen($trimedString));
+                return array(
+                    'node' => new \ParserGenerator\SyntaxTreeNode\Leaf($trimedString, $whitespaces),
+                    'offset' => $endPos
+                );
+            } else {
+                return array('node' => new \ParserGenerator\SyntaxTreeNode\Leaf($str), 'offset' => $endPos);
+            }
+        } else {
+            return false;
+        }
+    }
+
     protected function getNextNonrestrictedIndex($string, $fromIndex, $restrictedEnd)
-	{
-	    if (!isset($string[$fromIndex])) {
-		    return isset($restrictedEnd[$fromIndex]) ? null : $fromIndex;
-		}
-		
-	    $i = $fromIndex;
-		while(isset($restrictedEnd[$i]) || ($this->ignoreWhitespaces && isset(self::$whiteChars[$string[$i]]))) {
-		    $i++;
-			if (!isset($string[$i])) {
-			    return isset($restrictedEnd[$i]) ? null : $i;
-			}
-		}
-		
-		return $i;
-	}
+    {
+        if (!isset($string[$fromIndex])) {
+            return isset($restrictedEnd[$fromIndex]) ? null : $fromIndex;
+        }
+
+        $i = $fromIndex;
+        while (isset($restrictedEnd[$i]) || ($this->ignoreWhitespaces && isset(self::$whiteChars[$string[$i]]))) {
+            $i++;
+            if (!isset($string[$i])) {
+                return isset($restrictedEnd[$i]) ? null : $i;
+            }
+        }
+
+        return $i;
+    }
 }

--- a/src/GrammarNode/Branch.php
+++ b/src/GrammarNode/Branch.php
@@ -40,12 +40,13 @@ class Branch extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGen
             $indexes = array(-1 => $fromIndex);
             $optionCount = count($option);
             //!!! TODO:
-            for($i =0; $i < $optionCount; $i++) {
+            for ($i = 0; $i < $optionCount; $i++) {
                 $restrictedEnds[$i] = array();
             }
             $restrictedEnds[$optionCount - 1] = $restrictedEnd;
             while (true) {
-                $subNode = $option[$optionIndex]->rparse($string, $indexes[$optionIndex - 1], $restrictedEnds[$optionIndex]);
+                $subNode = $option[$optionIndex]->rparse($string, $indexes[$optionIndex - 1],
+                    $restrictedEnds[$optionIndex]);
                 if ($subNode) {
                     $subNodeOffset = $subNode['offset'];
                     $subnodes[$optionIndex] = $subNode['node'];

--- a/src/GrammarNode/BranchFactory.php
+++ b/src/GrammarNode/BranchFactory.php
@@ -5,20 +5,20 @@ namespace ParserGenerator\GrammarNode;
 class BranchFactory
 {
     const NAIVE = 'naive';
-	const FULL = 'full';
-	const PEG = 'PEG';
+    const FULL = 'full';
+    const PEG = 'PEG';
 
     public static function createBranch($branchType, $name)
-	{
-	    switch ($branchType) {
-		    case self::NAIVE:
-			    return new NaiveBranch($name);
-		    case self::FULL:
-			    return new Branch($name);
-		    case self::PEG:
-			    return new PEGBranch($name);
-		    default:
-			    throw new \Exception("Unknown branch type: $branchType");
-		}
-	}
+    {
+        switch ($branchType) {
+            case self::NAIVE:
+                return new NaiveBranch($name);
+            case self::FULL:
+                return new Branch($name);
+            case self::PEG:
+                return new PEGBranch($name);
+            default:
+                throw new \Exception("Unknown branch type: $branchType");
+        }
+    }
 }

--- a/src/GrammarNode/BranchStringCondition.php
+++ b/src/GrammarNode/BranchStringCondition.php
@@ -18,7 +18,8 @@ class BranchStringCondition extends \ParserGenerator\GrammarNode\BranchExtraCond
         $this->_functions = array();
 
         foreach ($conditionStrings as $detailType => $conditionString) {
-            $this->_functions[$detailType] = create_function('$string,$fromIndex,$toIndex,$node,$s', 'return ' . $conditionString . ';');
+            $this->_functions[$detailType] = create_function('$string,$fromIndex,$toIndex,$node,$s',
+                'return ' . $conditionString . ';');
         }
     }
 

--- a/src/GrammarNode/Choice.php
+++ b/src/GrammarNode/Choice.php
@@ -6,7 +6,7 @@ class Choice extends \ParserGenerator\GrammarNode\BaseNode
 {
     protected $choices;
     protected $tmpNodeName;
-	protected $reduce = array();
+    protected $reduce = array();
 
     public function __construct($choices)
     {
@@ -17,13 +17,13 @@ class Choice extends \ParserGenerator\GrammarNode\BaseNode
 
         $node = array();
         foreach ($choices as $choice) {
-		    if (is_array($choice)) {
-			    $node[] = $choice;
-				$this->reduce[] = false;
-			} else {
+            if (is_array($choice)) {
+                $node[] = $choice;
+                $this->reduce[] = false;
+            } else {
                 $node[] = array($choice);
-				$this->reduce[] = true;
-		    }
+                $this->reduce[] = true;
+            }
         };
 
         $this->grammarNode->setNode($node);
@@ -32,11 +32,11 @@ class Choice extends \ParserGenerator\GrammarNode\BaseNode
     public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
     {
         if ($rparseResult = $this->grammarNode->rparse($string, $fromIndex, $restrictedEnd)) {
-		    if ($this->reduce[$rparseResult['node']->getDetailType()]) {
+            if ($this->reduce[$rparseResult['node']->getDetailType()]) {
                 $rparseResult['node'] = $rparseResult['node']->getSubnode(0);
-			}
-			
-			return $rparseResult;
+            }
+
+            return $rparseResult;
         }
 
         return false;
@@ -58,9 +58,10 @@ class Choice extends \ParserGenerator\GrammarNode\BaseNode
         $this->grammarNode->setParser($parser);
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         $result = '';
-        foreach($this->choices as $choice) {
+        foreach ($this->choices as $choice) {
             $result .= ($result ? '|' : '') . (is_array($choice) ? implode(" ", $choice) : $choice);
         }
 

--- a/src/GrammarNode/Decorator.php
+++ b/src/GrammarNode/Decorator.php
@@ -16,19 +16,22 @@ class Decorator implements \ParserGenerator\GrammarNode\NodeInterface
         return $this->node->rparse($string, $fromIndex, $restrictedEnd);
     }
 
-    public static function undecorate($node) {
-        while($node instanceof self) {
+    public static function undecorate($node)
+    {
+        while ($node instanceof self) {
             $node = $node->node;
         }
 
         return $node;
     }
 
-    public function __toString() {
-        return (string) $this->node;
+    public function __toString()
+    {
+        return (string)$this->node;
     }
 
-    public function getDecoratedNode() {
+    public function getDecoratedNode()
+    {
         return $this->node;
     }
 

--- a/src/GrammarNode/ErrorTrackDecorator.php
+++ b/src/GrammarNode/ErrorTrackDecorator.php
@@ -24,11 +24,13 @@ class ErrorTrackDecorator extends Decorator
         return $result;
     }
 
-    public function getMaxCheck() {
+    public function getMaxCheck()
+    {
         return $this->maxCheck === -1 ? null : $this->maxCheck;
     }
 
-    public function reset() {
+    public function reset()
+    {
         $this->maxCheck = -1;
     }
 

--- a/src/GrammarNode/ItemRestrictions.php
+++ b/src/GrammarNode/ItemRestrictions.php
@@ -8,18 +8,19 @@ class ItemRestrictions extends \ParserGenerator\GrammarNode\Decorator
 
     public function __construct($node, $condition)
     {
-	    parent::__construct($node);
+        parent::__construct($node);
         $this->condition = $condition;
     }
-	
-	public function rparse($string, $fromIndex, $restrictedEnd) {
-	    while ($newResult = $this->node->rparse($string, $fromIndex, $restrictedEnd)) {
-		    if ($this->condition->check($string, $fromIndex, $newResult['offset'], $newResult['node'])) {
+
+    public function rparse($string, $fromIndex, $restrictedEnd)
+    {
+        while ($newResult = $this->node->rparse($string, $fromIndex, $restrictedEnd)) {
+            if ($this->condition->check($string, $fromIndex, $newResult['offset'], $newResult['node'])) {
                 return $newResult;
             }
             $restrictedEnd[$newResult['offset']] = $newResult['offset'];
         }
 
         return false;
-	}
+    }
 }

--- a/src/GrammarNode/LeafInterface.php
+++ b/src/GrammarNode/LeafInterface.php
@@ -2,5 +2,6 @@
 
 namespace ParserGenerator\GrammarNode;
 
-interface LeafInterface {
+interface LeafInterface
+{
 }

--- a/src/GrammarNode/LeafTime.php
+++ b/src/GrammarNode/LeafTime.php
@@ -25,7 +25,9 @@ class LeafTime extends \ParserGenerator\GrammarNode\BaseNode implements \ParserG
         $data = date_parse_from_format($this->format, $s);
 
         if (!empty($data['errors'])) {
-            foreach($data['errors'] as $key => $_) break;
+            foreach ($data['errors'] as $key => $_) {
+                break;
+            }
             $s = substr($s, 0, $key);
             $data = date_parse_from_format($this->format, $s);
             if (!empty($data['errors'])) {

--- a/src/GrammarNode/Lookahead.php
+++ b/src/GrammarNode/Lookahead.php
@@ -67,7 +67,8 @@ class Lookahead extends \ParserGenerator\GrammarNode\BaseNode
         return $result;
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         $lookaheadStr = ($this->positive ? '?' : '!') . $this->lookaheadNode;
         if ($this->mainNode === null) {
             return $lookaheadStr;

--- a/src/GrammarNode/NaiveBranch.php
+++ b/src/GrammarNode/NaiveBranch.php
@@ -11,7 +11,7 @@ class NaiveBranch extends \ParserGenerator\GrammarNode\Branch
         if (isset($this->parser->cache[$cacheStr])) {
             return $this->parser->cache[$cacheStr];
         }
-		$this->parser->cache[$cacheStr] = false;
+        $this->parser->cache[$cacheStr] = false;
 
         foreach ($this->node as $_optionIndex => $option) {
             $subnodes = array();
@@ -22,7 +22,8 @@ class NaiveBranch extends \ParserGenerator\GrammarNode\Branch
             $restrictedEnds = array(array(), array(), array(), array(), array(), array(), array(), array());
             $restrictedEnds[$optionCount - 1] = $restrictedEnd;
             while (true) {
-                $subNode = $option[$optionIndex]->rparse($string, $indexes[$optionIndex - 1], $restrictedEnds[$optionIndex]);
+                $subNode = $option[$optionIndex]->rparse($string, $indexes[$optionIndex - 1],
+                    $restrictedEnds[$optionIndex]);
                 if ($subNode) {
                     $subNodeOffset = $subNode['offset'];
                     $subnodes[$optionIndex] = $subNode['node'];

--- a/src/GrammarNode/Numeric.php
+++ b/src/GrammarNode/Numeric.php
@@ -25,7 +25,9 @@ class Numeric extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
                     $this->$key = $value;
                 }
             }
-            if (in_array($key, array('formatDec', 'formatHex', 'formatOct', 'formatBin', 'eatWhiteChars', 'allowFixedCharacters'), true)) {
+            if (in_array($key,
+                array('formatDec', 'formatHex', 'formatOct', 'formatBin', 'eatWhiteChars', 'allowFixedCharacters'),
+                true)) {
                 if (is_bool($value)) {
                     $this->$key = $value;
                 }
@@ -108,13 +110,14 @@ class Numeric extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
         return false;
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         $modifiers = $this->requireFixedCharacters ? $this->requireFixedCharacters : '';
         $modifiers .= $this->formatBin ? 'b' : '';
         $modifiers .= $this->formatHex ? 'h' : '';
         $modifiers .= $this->formatOct ? 'o' : '';
         $modifiers .= $this->formatDec ? 'd' : '';
         $modifiers = $modifiers == 'd' ? '' : ('/' . $modifiers);
-        return (($this->min === null) ? '-inf' : $this->min) . '..' .  (($this->max === null) ? 'inf' : $this->max) . $modifiers;
+        return (($this->min === null) ? '-inf' : $this->min) . '..' . (($this->max === null) ? 'inf' : $this->max) . $modifiers;
     }
 }

--- a/src/GrammarNode/PEGBranch.php
+++ b/src/GrammarNode/PEGBranch.php
@@ -9,35 +9,35 @@ class PEGBranch extends \ParserGenerator\GrammarNode\Branch
         $cacheStr = $fromIndex . '-' . $this->nodeName;
 
         if (!isset($this->parser->cache[$cacheStr])) {
-			foreach ($this->node as $_optionIndex => $option) {
-				$index = $fromIndex;
-				$subnodes = array();
-				
-				foreach($option as $sequenceItem) {
-					$subnode = $sequenceItem->rparse($string, $index, array());
-					if ($subnode) {
-						$subnodes[] = $subnode['node'];
-						$index = $subnode['offset'];
-					} else {
-						continue 2;
-					}
-				}
+            foreach ($this->node as $_optionIndex => $option) {
+                $index = $fromIndex;
+                $subnodes = array();
 
-				$node = new \ParserGenerator\SyntaxTreeNode\Branch($this->nodeShortName, $_optionIndex, $subnodes);
-				$r = array('node' => $node, 'offset' => $index);
-				$this->parser->cache[$cacheStr] = $r;
-				return isset($restrictedEnd[$index]) ? false : $r;
-			}
-			
-			$this->parser->cache[$cacheStr] = false;
-			return false;
-		}
-		
+                foreach ($option as $sequenceItem) {
+                    $subnode = $sequenceItem->rparse($string, $index, array());
+                    if ($subnode) {
+                        $subnodes[] = $subnode['node'];
+                        $index = $subnode['offset'];
+                    } else {
+                        continue 2;
+                    }
+                }
+
+                $node = new \ParserGenerator\SyntaxTreeNode\Branch($this->nodeShortName, $_optionIndex, $subnodes);
+                $r = array('node' => $node, 'offset' => $index);
+                $this->parser->cache[$cacheStr] = $r;
+                return isset($restrictedEnd[$index]) ? false : $r;
+            }
+
+            $this->parser->cache[$cacheStr] = false;
+            return false;
+        }
+
         $r = $this->parser->cache[$cacheStr];
-		if ($r !== false && !isset($restrictedEnd[$r['offset']])) {
+        if ($r !== false && !isset($restrictedEnd[$r['offset']])) {
             return $r;
         } else {
             return false;
-        }		
+        }
     }
 }

--- a/src/GrammarNode/ParametrizedNode.php
+++ b/src/GrammarNode/ParametrizedNode.php
@@ -30,7 +30,7 @@ class ParametrizedNode extends BaseNode implements \ParserGenerator\ParserAwareI
     {
         $params = $this->params;
         $parser = $this->parser;
-        return GrammarNodeCopier::copy($this->abstractNode, function($node) use ($params, $parser) {
+        return GrammarNodeCopier::copy($this->abstractNode, function ($node) use ($params, $parser) {
             if ($node instanceof ErrorTrackDecorator) {
                 $node = $node->getDecoratedNode();
             }

--- a/src/GrammarNode/PredefinedString.php
+++ b/src/GrammarNode/PredefinedString.php
@@ -36,7 +36,8 @@ class PredefinedString extends \ParserGenerator\GrammarNode\BaseNode Implements 
 
                         return false;
                     } else {
-                        $node = new \ParserGenerator\SyntaxTreeNode\PredefinedString($val, $this->eatWhiteChars ? $match[0] : '');
+                        $node = new \ParserGenerator\SyntaxTreeNode\PredefinedString($val,
+                            $this->eatWhiteChars ? $match[0] : '');
 
                         return array('node' => $node, 'offset' => $nextPos + 1);
                     }

--- a/src/GrammarNode/Regex.php
+++ b/src/GrammarNode/Regex.php
@@ -35,7 +35,8 @@ class Regex extends \ParserGenerator\GrammarNode\BaseNode Implements \ParserGene
             if (isset($match[1])) {
                 $offset = strlen($match[$this->eatWhiteChars ? 0 : 1]) + $fromIndex;
                 if (!isset($restrictedEnd[$offset])) {
-                    $node = new \ParserGenerator\SyntaxTreeNode\Leaf($match[1], $this->eatWhiteChars ? substr($match[0], strlen($match[1])) : '');
+                    $node = new \ParserGenerator\SyntaxTreeNode\Leaf($match[1],
+                        $this->eatWhiteChars ? substr($match[0], strlen($match[1])) : '');
 
                     if ($this->lastMatch < $fromIndex) {
                         $this->lastMatch = $fromIndex;

--- a/src/GrammarNode/Series.php
+++ b/src/GrammarNode/Series.php
@@ -49,7 +49,11 @@ class Series extends \ParserGenerator\GrammarNode\BranchDecorator
     public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
     {
         if ($this->from0 && !$this->greedy && !isset($restrictedEnd[$fromIndex])) {
-            return array('node' => new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, $this->resultDetailType, array(), (bool) $this->separator), 'offset' => $fromIndex);
+            return array(
+                'node' => new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, $this->resultDetailType,
+                    array(), (bool)$this->separator),
+                'offset' => $fromIndex
+            );
         }
 
         if ($rparseResult = $this->node->rparse($string, $fromIndex, $restrictedEnd)) {
@@ -58,7 +62,11 @@ class Series extends \ParserGenerator\GrammarNode\BranchDecorator
         }
 
         if ($this->from0 && !isset($restrictedEnd[$fromIndex])) {
-            return array('node' => new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, $this->resultDetailType, array(), (bool) $this->separator), 'offset' => $fromIndex);
+            return array(
+                'node' => new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, $this->resultDetailType,
+                    array(), (bool)$this->separator),
+                'offset' => $fromIndex
+            );
         }
 
         return false;
@@ -78,30 +86,34 @@ class Series extends \ParserGenerator\GrammarNode\BranchDecorator
         }
         $astSubnodes[] = $ast->getSubnode(0);
 
-        return new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, $this->resultDetailType, $astSubnodes, (bool) $this->separator);
+        return new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, $this->resultDetailType, $astSubnodes,
+            (bool)$this->separator);
     }
-	
-	public function getNode()
-	{
-       $node = $this->separator ? array(array($this->mainNode, $this->separator)) : array(array($this->mainNode));
-       if ($this->from0) {
-           $node[] = array();
-       }
-	   return $node;
-	}
 
-    public function getMainNode() {
+    public function getNode()
+    {
+        $node = $this->separator ? array(array($this->mainNode, $this->separator)) : array(array($this->mainNode));
+        if ($this->from0) {
+            $node[] = array();
+        }
+        return $node;
+    }
+
+    public function getMainNode()
+    {
         return $this->mainNode;
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         $op = array(array('+', '++'), array('*', '**'));
         return $this->mainNode . $op[$this->from0][$this->greedy] . ($this->separator ?: '');
     }
 
     public function copy($copyCallback)
     {
-        $copy = new static($copyCallback($this->mainNode), $copyCallback($this->separator), $this->from0, $this->greedy);
+        $copy = new static($copyCallback($this->mainNode), $copyCallback($this->separator), $this->from0,
+            $this->greedy);
         $copy->setParser($this->getParser());
         return $copy;
     }

--- a/src/GrammarNode/Unorder.php
+++ b/src/GrammarNode/Unorder.php
@@ -24,24 +24,28 @@ class Unorder extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
         $this->tmpNodeName = '&unorder/' . spl_object_hash($this);
     }
 
-    public function addChoice($choice, $mod) {
+    public function addChoice($choice, $mod)
+    {
         $this->choices[] = $choice;
         $this->mod[] = $mod;
     }
 
-    protected function internalParse($string, $fromIndex, $restrictedEnd, $required, $left) {
-        foreach($this->choices as $key => $choice) {
+    protected function internalParse($string, $fromIndex, $restrictedEnd, $required, $left)
+    {
+        foreach ($this->choices as $key => $choice) {
             if ($left[$key] > 0) {
                 $choiceRestrictedEnd = array();
                 $isRequired = !empty($required[$key]);
                 unset($required[$key]);
                 $left[$key]--;
-                while($choiceResult = $choice->rparse($string, $fromIndex, $choiceRestrictedEnd)) {
+                while ($choiceResult = $choice->rparse($string, $fromIndex, $choiceRestrictedEnd)) {
                     $afterChoiceIndex = $choiceResult['offset'];
                     $separatorRestrictedEnd = array();
-                    while($separatorResult = $this->separator->rparse($string, $afterChoiceIndex, $separatorRestrictedEnd)) {
+                    while ($separatorResult = $this->separator->rparse($string, $afterChoiceIndex,
+                        $separatorRestrictedEnd)) {
                         $afterSeparatorIndex = $separatorResult['offset'];
-                        if ($next = $this->internalParse($string, $afterSeparatorIndex, $restrictedEnd, $required, $left)) {
+                        if ($next = $this->internalParse($string, $afterSeparatorIndex, $restrictedEnd, $required,
+                            $left)) {
                             array_push($next['nodes'], $separatorResult['node'], $choiceResult['node']);
                             return $next;
                         }
@@ -73,7 +77,7 @@ class Unorder extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
     public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
     {
         $required = array();
-        foreach($this->choices as $key => $choice) {
+        foreach ($this->choices as $key => $choice) {
             $mod = $this->mod[$key];
             $left[$key] = ($mod == '*' || $mod == '+') ? static::MAX : 1;
             if ($mod == '' || $mod == '1' || $mod == '+') {
@@ -82,7 +86,8 @@ class Unorder extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
         }
 
         if ($result = $this->internalParse($string, $fromIndex, $restrictedEnd, $required, $left)) {
-            $node = new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, '', array_reverse($result['nodes']), true);
+            $node = new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, '', array_reverse($result['nodes']),
+                true);
             return array('node' => $node, 'offset' => $result['offset']);
         }
 
@@ -97,7 +102,7 @@ class Unorder extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
     public function setParser(\ParserGenerator\Parser $parser)
     {
         $this->parser = $parser;
-        foreach($this->choices as $choice) {
+        foreach ($this->choices as $choice) {
             if ($choice instanceof \ParserGenerator\ParserAwareInterface) {
                 $choice->setParser($parser);
             }
@@ -109,7 +114,8 @@ class Unorder extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
         return $this->parser;
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         return "unorder";
         return '(' . implode(' | ', $this->choices) . ')';
     }

--- a/src/GrammarNode/WhitespaceContextCheck.php
+++ b/src/GrammarNode/WhitespaceContextCheck.php
@@ -29,9 +29,13 @@ class WhitespaceContextCheck extends BaseNode implements LeafInterface
             $offset = 1;
         }
 
-        if (($this->char === null) ? in_array($stringChar, self::$whiteCharacters, true) : ($this->char === $stringChar)) {
+        if (($this->char === null) ? in_array($stringChar, self::$whiteCharacters,
+            true) : ($this->char === $stringChar)) {
             if (!isset($restrictedEnd[$fromIndex + $offset])) {
-                return array('node' => new \ParserGenerator\SyntaxTreeNode\Leaf($substring), 'offset' => $fromIndex + $offset);
+                return array(
+                    'node' => new \ParserGenerator\SyntaxTreeNode\Leaf($substring),
+                    'offset' => $fromIndex + $offset
+                );
             }
         }
 

--- a/src/GrammarNodeCopier.php
+++ b/src/GrammarNodeCopier.php
@@ -9,15 +9,18 @@
 namespace ParserGenerator;
 
 
-class GrammarNodeCopier {
-    public static function copy($node, $callback) {
-        $_copy = function($node) use ($callback, &$_copy) {
+class GrammarNodeCopier
+{
+    public static function copy($node, $callback)
+    {
+        $_copy = function ($node) use ($callback, &$_copy) {
             static $i;
             if ($node === null) {
                 return null;
-            } if (is_array($node)) {
+            }
+            if (is_array($node)) {
                 $result = array();
-                foreach($node as $index => $subnode) {
+                foreach ($node as $index => $subnode) {
                     $result[$index] = $_copy($subnode);
                 }
                 return $result;
@@ -35,4 +38,4 @@ class GrammarNodeCopier {
 
         return $node->copy($_copy);
     }
-} 
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -40,8 +40,6 @@ require_once 'GrammarParser.php';
 
 namespace ParserGenerator;
 
-use ParserGenerator\GrammarNode\ErrorTrackDecorator;
-
 class Parser
 {
     public $cache;
@@ -57,35 +55,36 @@ class Parser
         $this->options = $options;
 
         foreach ($this->grammar as $name => $node) {
-                $grammarNode = new \ParserGenerator\GrammarNode\BranchDecorator(new \ParserGenerator\GrammarNode\Branch($name));
-                $this->grammar[$name] = $grammarNode;
-                $this->grammar[$name]->setParser($this);
+            $grammarNode = new \ParserGenerator\GrammarNode\BranchDecorator(new \ParserGenerator\GrammarNode\Branch($name));
+            $this->grammar[$name] = $grammarNode;
+            $this->grammar[$name]->setParser($this);
         }
 
         $this->grammar['string'] = new \ParserGenerator\GrammarNode\PredefinedString(true);
 
         foreach ($grammar as $name => $node) {
-				$grammarNodeOptions = array();
-				foreach ($node as $optionIndex => $option) {
-					foreach ((array)$option as $seqIndex => $seq) {
-						if (is_string($seq)) {
-							if (substr($seq, 0, 1) == ':') {
-								if (substr($seq, 1, 1) == '/') {
-									$grammarNodeOptions[$optionIndex][$seqIndex] = new \ParserGenerator\GrammarNode\Regex(substr($seq, 1), true);
-								} else {
-									$grammarNodeOptions[$optionIndex][$seqIndex] = $this->grammar[substr($seq, 1)];
-								}
-							} else {
-								$grammarNodeOptions[$optionIndex][$seqIndex] = new \ParserGenerator\GrammarNode\TextS($seq);
-							}
-						} elseif ($seq instanceof \ParserGenerator\GrammarNode\NodeInterface) {
-							$grammarNodeOptions[$optionIndex][$seqIndex] = $seq;
-						} else {
-							throw new \Exception('incorrect sequenceitem');
-						}
-					}
-				}
-				$this->grammar[$name]->setNode($grammarNodeOptions);
+            $grammarNodeOptions = array();
+            foreach ($node as $optionIndex => $option) {
+                foreach ((array)$option as $seqIndex => $seq) {
+                    if (is_string($seq)) {
+                        if (substr($seq, 0, 1) == ':') {
+                            if (substr($seq, 1, 1) == '/') {
+                                $grammarNodeOptions[$optionIndex][$seqIndex] = new \ParserGenerator\GrammarNode\Regex(substr($seq,
+                                    1), true);
+                            } else {
+                                $grammarNodeOptions[$optionIndex][$seqIndex] = $this->grammar[substr($seq, 1)];
+                            }
+                        } else {
+                            $grammarNodeOptions[$optionIndex][$seqIndex] = new \ParserGenerator\GrammarNode\TextS($seq);
+                        }
+                    } elseif ($seq instanceof \ParserGenerator\GrammarNode\NodeInterface) {
+                        $grammarNodeOptions[$optionIndex][$seqIndex] = $seq;
+                    } else {
+                        throw new \Exception('incorrect sequenceitem');
+                    }
+                }
+            }
+            $this->grammar[$name]->setNode($grammarNodeOptions);
         }
     }
 
@@ -138,13 +137,13 @@ class Parser
         } else {
             $this->buildFromString($grammar, $options);
         }
-		
-		/*$that = $this;
-		$this->iterateOverNodes(function($node) use ($that) {
-		    if ($node instanceof \ParserGenerator\GrammarNode\BranchInterface && empty($that->grammar[$node->getNodeName()])) {
-		        $that->grammar[$node->getNodeName()] = $node;
-		    }
-		});*/
+
+        /*$that = $this;
+        $this->iterateOverNodes(function($node) use ($that) {
+            if ($node instanceof \ParserGenerator\GrammarNode\BranchInterface && empty($that->grammar[$node->getNodeName()])) {
+                $that->grammar[$node->getNodeName()] = $node;
+            }
+        });*/
     }
 
     public function parse($string, $nodeToParseName = 'start')
@@ -261,15 +260,15 @@ class Parser
     public function generalizeErrors($errors)
     {
         $errorsByHash = array();
-        foreach($errors as $error) {
+        foreach ($errors as $error) {
             $errorsByHash[spl_object_hash($error)] = $error;
         }
 
-        foreach($this->grammar as $grammarNode) {
+        foreach ($this->grammar as $grammarNode) {
             if ($grammarNode instanceof \ParserGenerator\GrammarNode\BranchInterface) {
                 $generalizeThisNode = false;
 
-                foreach($grammarNode->getNode() as $sequence) {
+                foreach ($grammarNode->getNode() as $sequence) {
                     if (isset($sequence[0]) && $sequence[0] instanceof \ParserGenerator\GrammarNode\LeafInterface) {
                         if (isset($errorsByHash[spl_object_hash($sequence[0])])) {
                             unset($errorsByHash[spl_object_hash($sequence[0])]);
@@ -284,7 +283,7 @@ class Parser
             }
         }
 
-        foreach($errorsByHash as $hash => $error) {
+        foreach ($errorsByHash as $hash => $error) {
             if (empty($errorsByHash[$hash])) {
                 continue;
             }
@@ -292,9 +291,9 @@ class Parser
             $subErrorsByHash = array($hash => $error);
             do {
                 $oneMoreIteration = false;
-                foreach($subErrorsByHash as $subError) {
+                foreach ($subErrorsByHash as $subError) {
                     if ($subError instanceof \ParserGenerator\GrammarNode\BranchInterface) {
-                        foreach($subError->getNode() as $sequence) {
+                        foreach ($subError->getNode() as $sequence) {
                             if (isset($sequence[0]) && empty($subErrorsByHash[spl_object_hash($sequence[0])])) {
                                 $subErrorsByHash[spl_object_hash($sequence[0])] = $sequence[0];
                                 $oneMoreIteration = true;
@@ -303,7 +302,7 @@ class Parser
                         }
                     }
                 }
-            } while($oneMoreIteration);
+            } while ($oneMoreIteration);
         }
 
         return $errorsByHash;

--- a/src/ParserAwareInterface.php
+++ b/src/ParserAwareInterface.php
@@ -6,5 +6,6 @@ namespace ParserGenerator;
 interface ParserAwareInterface
 {
     public function getParser();
+
     public function setParser(Parser $parser);
-} 
+}

--- a/src/RegexUtil.php
+++ b/src/RegexUtil.php
@@ -34,7 +34,12 @@ class RegexUtil
             'regexModifiers' => array(':/[imsxeADSUXJu]*/'),
             'regex' => array(array(':regexLine', '|', ':regex'), ':regexLine'),
             'regexLine' => array(array(':regexToken', ':regexLine'), ''),
-            'regexToken' => array(':startMatcher', ':endMatcher', ':lookAround', array(':singleStatement', ':repetition', ':nonGreedy')),
+            'regexToken' => array(
+                ':startMatcher',
+                ':endMatcher',
+                ':lookAround',
+                array(':singleStatement', ':repetition', ':nonGreedy')
+            ),
             'lookAround' => array(array('(?', ':lookArroundType', ':regex', ')')),
             'lookArroundType' => array('=', '!', '<=', '<!'),
             'singleStatement' => array(
@@ -43,11 +48,23 @@ class RegexUtil
                 array('[', ':characterSet', ']'),
                 array('[^', ':characterSet', ']'),
                 array('.'),
-                array(':character')),
-            'characterSet' => array(array(':simpleCharacter', '-', ':simpleCharacter', ':characterSet'), array(':character', ':characterSet'), ''),
+                array(':character')
+            ),
+            'characterSet' => array(
+                array(':simpleCharacter', '-', ':simpleCharacter', ':characterSet'),
+                array(':character', ':characterSet'),
+                ''
+            ),
             'character' => array(array(':/\\\\./'), ':simpleCharacter'),
             'simpleCharacter' => array(':/[^\\\\\\]\\[\\+\\*\\?\\|\\(\\)\\$\\^\\/]/'),
-            'repetition' => array('?', '+', '*', array('{', ':/\d+/', '}'), array('{', ':/\d+/', ',', ':/\d*/', '}'), ''),
+            'repetition' => array(
+                '?',
+                '+',
+                '*',
+                array('{', ':/\d+/', '}'),
+                array('{', ':/\d+/', ',', ':/\d*/', '}'),
+                ''
+            ),
             'nonGreedy' => array('?', ''),
             'startMatcher' => array('^'),
             'endMatcher' => array('$'),
@@ -212,7 +229,8 @@ class RegexUtil
                         if (!$node->getSubnode(2)) {
                             print_r($node);
                         };
-                        return $this->getCharacterRange((string)$node->getSubnode(0), (string)$node->getSubnode(2)) + $this->_getStartCharacters($node->getSubnode(3));
+                        return $this->getCharacterRange((string)$node->getSubnode(0),
+                                (string)$node->getSubnode(2)) + $this->_getStartCharacters($node->getSubnode(3));
                     case 1:
                         return $this->_getStartCharacters($node->getSubnode(0)) + $this->_getStartCharacters($node->getSubnode(1));
                     case 2:
@@ -293,7 +311,8 @@ class RegexUtil
         switch ($node->getType()) {
             case 'regex':
                 if ($node->getDetailType() === 0) {
-                    return rand(0, 1) ? $this->_generateString($node->getSubnode(0)) : $this->_generateString($node->getSubnode(2));
+                    return rand(0,
+                        1) ? $this->_generateString($node->getSubnode(0)) : $this->_generateString($node->getSubnode(2));
                 } else {
                     return $this->_generateString($node->getSubnode(0));
                 }

--- a/src/SyntaxTreeNode/Base.php
+++ b/src/SyntaxTreeNode/Base.php
@@ -16,15 +16,19 @@ abstract class Base
     const TO_STRING_REDUCED_WHITESPACES = 4;
 
     abstract public function getLeftLeaf();
+
     abstract public function getRightLeaf();
+
     abstract public function toString($mode = \ParserGenerator\SyntaxTreeNode\Base::TO_STRING_NO_WHITESPACES);
 
-    public function setAfterContent($newValue) {
+    public function setAfterContent($newValue)
+    {
         $this->getRightLeaf()->afterContent = $newValue;
         return $this;
     }
 
-    public function getAfterContent() {
+    public function getAfterContent()
+    {
         return $this->getRightLeaf()->afterContent;
     }
 }

--- a/src/SyntaxTreeNode/Branch.php
+++ b/src/SyntaxTreeNode/Branch.php
@@ -15,29 +15,35 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
         $this->subnodes = $subnodes;
     }
 
-    public function getType() {
+    public function getType()
+    {
         return $this->type;
     }
 
-    public function setType($newValue) {
+    public function setType($newValue)
+    {
         $this->type = $newValue;
         return $this;
     }
 
-    public function getDetailType() {
+    public function getDetailType()
+    {
         return $this->detailType;
     }
 
-    public function setDetailType($newValue) {
+    public function setDetailType($newValue)
+    {
         $this->detailType = $newValue;
         return $this;
     }
 
-    public function getSubnode($index) {
+    public function getSubnode($index)
+    {
         return isset($this->subnodes[$index]) ? $this->subnodes[$index] : null;
     }
 
-    public function getNestedSubnode($param1) {
+    public function getNestedSubnode($param1)
+    {
         if (is_array($param1)) {
             $args = $param1;
         } else {
@@ -56,7 +62,8 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
         }
     }
 
-    public function setSubnode($index, $newValue) {
+    public function setSubnode($index, $newValue)
+    {
         if ($index === null) {
             $this->subnodes[] = $newValue;
         } else {
@@ -65,16 +72,19 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
         return $this;
     }
 
-    public function getSubnodes() {
+    public function getSubnodes()
+    {
         return $this->subnodes;
     }
 
-    public function setSubnodes($subnodes) {
+    public function setSubnodes($subnodes)
+    {
         $this->subnodes = $subnodes;
         return $this;
     }
 
-    public function dump($maxNestLevel = -1, $offset = '') {
+    public function dump($maxNestLevel = -1, $offset = '')
+    {
         $result = $this->type . ':' . $this->detailType;
         if ($maxNestLevel == 0) {
             return $result;
@@ -84,7 +94,7 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
         }
 
         $result .= " (\n";
-        foreach($this->subnodes as $i => $subnode) {
+        foreach ($this->subnodes as $i => $subnode) {
             $result .= $offset . '  ' . $i . ' = ' . $subnode->dump($maxNestLevel - 1, $offset . '  ') . "\n";
         }
         return $result . $offset . ')';
@@ -232,7 +242,7 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
     public function compare($anotherNode, $compareOptions = \ParserGenerator\SyntaxTreeNode\Base::COMPARE_DEFAULT)
     {
 
-        if (!($anotherNode instanceof  \ParserGenerator\SyntaxTreeNode\Branch)) {
+        if (!($anotherNode instanceof \ParserGenerator\SyntaxTreeNode\Branch)) {
             return false;
         }
 
@@ -290,21 +300,21 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
     {
         return $this->subnodes[count($this->subnodes) - 1]->getRightLeaf();
     }
-	
-	public function refreshOwners($recursive = true)
-	{
-	    foreach($this->subnodes as $subnode) {
-		    $subnode->owner = $this;
-			if ($subnode instanceof Branch && $recursive) {
-			    $subnode->refreshOwners($recursive);
-			}
-		}
-	}
+
+    public function refreshOwners($recursive = true)
+    {
+        foreach ($this->subnodes as $subnode) {
+            $subnode->owner = $this;
+            if ($subnode instanceof Branch && $recursive) {
+                $subnode->refreshOwners($recursive);
+            }
+        }
+    }
 
     public function nearestOwner($type)
     {
         $owner = $this;
-        while(isset($owner->owner)) {
+        while (isset($owner->owner)) {
             $owner = $owner->owner;
             if ($owner->is($type)) {
                 return $owner;
@@ -317,10 +327,10 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
         $callback($this, $anotherNode);
 
         if (!($anotherNode instanceof self)) {
-            return ;
+            return;
         }
 
-        foreach($this->subnodes as $i => $subnode) {
+        foreach ($this->subnodes as $i => $subnode) {
             $subnode->iterateWith(isset($anotherNode->subnodes[$i]) ? $anotherNode->subnodes[$i] : null, $callback);
         }
     }
@@ -333,7 +343,7 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
         }
         $copy->owner = null;
 
-        $this->iterateWith($copy, function($that, $copy) {
+        $this->iterateWith($copy, function ($that, $copy) {
             $copy->origin = isset($that->origin) ? $that->origin : $that;
         });
 

--- a/src/SyntaxTreeNode/Leaf.php
+++ b/src/SyntaxTreeNode/Leaf.php
@@ -13,16 +13,19 @@ class Leaf extends \ParserGenerator\SyntaxTreeNode\Base
         $this->afterContent = $afterContent;
     }
 
-    public function getContent() {
+    public function getContent()
+    {
         return $this->content;
     }
 
-    public function setContent($newValue) {
+    public function setContent($newValue)
+    {
         $this->content = $newValue;
         return $this;
     }
 
-    public function dump($maxNestLevel = -1) {
+    public function dump($maxNestLevel = -1)
+    {
         return $this->content;
     }
 

--- a/src/SyntaxTreeNode/Root.php
+++ b/src/SyntaxTreeNode/Root.php
@@ -2,34 +2,34 @@
 
 namespace ParserGenerator\SyntaxTreeNode;
 
-use \ParserGenerator\SyntaxTreeNode\Base;
-
 class Root extends \ParserGenerator\SyntaxTreeNode\Branch
 {
-	protected $beforeContent = '';
+    protected $beforeContent = '';
 
-	public function __construct($type, $detailType, $subnodes = array(), $beforeContent = '')
+    public function __construct($type, $detailType, $subnodes = array(), $beforeContent = '')
     {
         parent::__construct($type, $detailType, $subnodes);
         $this->beforeContent = $beforeContent;
     }
 
-    public function setBeforeContent($newValue) {
+    public function setBeforeContent($newValue)
+    {
         $this->beforeContent = $newValue;
         return $this;
     }
 
-    public function getBeforeContent() {
+    public function getBeforeContent()
+    {
         return $this->beforeContent;
     }
 
-	public function toString($mode = Base::TO_STRING_NO_WHITESPACES)
+    public function toString($mode = Base::TO_STRING_NO_WHITESPACES)
     {
         return ($mode == Base::TO_STRING_ORIGINAL ? $this->beforeContent : '') . parent::toString($mode);
     }
 
     public static function createFromPrototype(\ParserGenerator\SyntaxTreeNode\Branch $prototype)
     {
-    	return new self($prototype->type, $prototype->detailType, $prototype->subnodes);
+        return new self($prototype->type, $prototype->detailType, $prototype->subnodes);
     }
 }

--- a/src/SyntaxTreeNode/Series.php
+++ b/src/SyntaxTreeNode/Series.php
@@ -2,7 +2,8 @@
 
 namespace ParserGenerator\SyntaxTreeNode;
 
-class Series extends \ParserGenerator\SyntaxTreeNode\Branch {
+class Series extends \ParserGenerator\SyntaxTreeNode\Branch
+{
     protected $isWithSeparator;
 
     public function __construct($type, $detailType, $subnodes = array(), $isWithSeparator = false)
@@ -20,14 +21,15 @@ class Series extends \ParserGenerator\SyntaxTreeNode\Branch {
         $subnodesCount = count($this->subnodes);
         $result = array();
 
-        for($i = 0; $i < $subnodesCount; $i += 2) {
+        for ($i = 0; $i < $subnodesCount; $i += 2) {
             $result[] = $this->subnodes[$i];
         }
 
         return $result;
     }
 
-    public function getSeparators() {
+    public function getSeparators()
+    {
         if (!$this->isWithSeparator) {
             return array();
         }
@@ -35,7 +37,7 @@ class Series extends \ParserGenerator\SyntaxTreeNode\Branch {
         $subnodesCount = count($this->subnodes);
         $result = array();
 
-        for($i = 1; $i < $subnodesCount; $i += 2) {
+        for ($i = 1; $i < $subnodesCount; $i += 2) {
             $result[] = $this->subnodes[$i];
         }
 
@@ -52,26 +54,27 @@ class Series extends \ParserGenerator\SyntaxTreeNode\Branch {
         if (is_string($callback)) {
             $compareBy = $callback;
             $callback = function ($a, $b) use ($compareBy) {
-                return strnatcmp((string) $a->findFirst($compareBy), (string) $b->findFirst($compareBy));
+                return strnatcmp((string)$a->findFirst($compareBy), (string)$b->findFirst($compareBy));
             };
         } elseif ($callback === null) {
             $callback = function ($a, $b) {
-                return strnatcmp((string) $a, (string) $b);
+                return strnatcmp((string)$a, (string)$b);
             };
         }
 
         $mainNodes = $this->getMainNodes();
         usort($mainNodes, $callback);
 
-        foreach($mainNodes as $index => $node) {
+        foreach ($mainNodes as $index => $node) {
             $this->subnodes[$index * 2] = $node;
         }
     }
 
-    public function findFirstInMainNodes($type, $addNullValues = false) {
+    public function findFirstInMainNodes($type, $addNullValues = false)
+    {
         $result = array();
 
-        foreach($this->getMainNodes() as $node) {
+        foreach ($this->getMainNodes() as $node) {
             if ($node instanceof \ParserGenerator\SyntaxTreeNode\Branch) {
                 $value = $node->findFirst($type);
             } else {

--- a/tests/Examples/CSVParserTest.php
+++ b/tests/Examples/CSVParserTest.php
@@ -2,7 +2,8 @@
 
 class CSVParserTest extends PHPUnit_Framework_TestCase
 {
-    public function testBase() {
+    public function testBase()
+    {
         $parser = new \ParserGenerator\Examples\CSVParser();
 
         $expected = array(
@@ -13,7 +14,8 @@ class CSVParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $parser->parseCSV("r1c1,r1c2\nr2c1,r2c2"));
     }
 
-    public function testQuoted() {
+    public function testQuoted()
+    {
         $parser = new \ParserGenerator\Examples\CSVParser();
 
         $expected = array(
@@ -24,7 +26,8 @@ class CSVParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $parser->parseCSV("\"r1c1\" , \"r1c2\"\n\"r2c1\",\"r2c2\""));
     }
 
-    public function testPreserveSpaces() {
+    public function testPreserveSpaces()
+    {
         $parser = new \ParserGenerator\Examples\CSVParser();
 
         $expected = array(
@@ -34,7 +37,8 @@ class CSVParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $parser->parseCSV("  c1  , c2 "));
     }
 
-    public function testProperEscaping() {
+    public function testProperEscaping()
+    {
         $parser = new \ParserGenerator\Examples\CSVParser();
 
         $expected = array(

--- a/tests/Examples/JSONFormaterTest.php
+++ b/tests/Examples/JSONFormaterTest.php
@@ -1,7 +1,9 @@
 <?php
 
-class JSONFormaterTest extends PHPUnit_Framework_TestCase {
-    public function testSetIndention() {
+class JSONFormaterTest extends PHPUnit_Framework_TestCase
+{
+    public function testSetIndention()
+    {
         $formater = new \ParserGenerator\Examples\JSONFormater();
 
         $jsonTree = $formater->parse('{"a":23,"b":false}');
@@ -9,9 +11,9 @@ class JSONFormaterTest extends PHPUnit_Framework_TestCase {
 
         $nl = "\n";
         $expected = '{' . $nl .
-        '    "a": 23,'. $nl .
-        '    "b": false'. $nl .
-        '}';
+            '    "a": 23,' . $nl .
+            '    "b": false' . $nl .
+            '}';
 
         $this->assertEquals($expected, $jsonTree->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
 
@@ -19,13 +21,13 @@ class JSONFormaterTest extends PHPUnit_Framework_TestCase {
         $formater->setIndention($jsonTree);
 
         $expected = '[' . $nl .
-            '    {'. $nl .
+            '    {' . $nl .
             '        "a": 0,' . $nl .
             '        "b": 34' . $nl .
-            '    },'. $nl .
-            '    {'. $nl .
+            '    },' . $nl .
+            '    {' . $nl .
             '        "x": 17' . $nl .
-            '    }'. $nl .
+            '    }' . $nl .
             ']';
 
         $this->assertEquals($expected, $jsonTree->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));

--- a/tests/Examples/JSONParserTest.php
+++ b/tests/Examples/JSONParserTest.php
@@ -22,7 +22,8 @@ class JSONParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(1, 2, 3), $jsonParser->getValue('[1, 2, 3]'));
         $this->assertEquals(array("1, 2", "3"), $jsonParser->getValue('["1, 2", "3"]'));
         $this->assertEquals(array(array(), array(array())), $jsonParser->getValue('[[],[[]]]'));
-        $this->assertEquals(array(array("a1", "a2"), array("b1", "b2")), $jsonParser->getValue('[["a1", "a2"], ["b1", "b2"]]'));
+        $this->assertEquals(array(array("a1", "a2"), array("b1", "b2")),
+            $jsonParser->getValue('[["a1", "a2"], ["b1", "b2"]]'));
     }
 
     public function testObject()
@@ -30,8 +31,10 @@ class JSONParserTest extends PHPUnit_Framework_TestCase
         $jsonParser = new \ParserGenerator\Examples\JSONParser();
         $this->assertEquals(array(), $jsonParser->getValue('{}'));
         $this->assertEquals(array("x" => "x"), $jsonParser->getValue('{"x":"x"}'));
-        $this->assertEquals(array("x" => 4, "y" => 5, "color" => "red", "visible" => true), $jsonParser->getValue('{"x": 4, "y": 5, "color":"red", "visible":true}'));
-        $this->assertEquals(array("a" => array(), "b" => array("c" => "c")), $jsonParser->getValue('{"a" : {}, "b":{"c": "c"}}'));
+        $this->assertEquals(array("x" => 4, "y" => 5, "color" => "red", "visible" => true),
+            $jsonParser->getValue('{"x": 4, "y": 5, "color":"red", "visible":true}'));
+        $this->assertEquals(array("a" => array(), "b" => array("c" => "c")),
+            $jsonParser->getValue('{"a" : {}, "b":{"c": "c"}}'));
 
     }
 

--- a/tests/Examples/PostfixToInfixNotationTranslatorTest.php
+++ b/tests/Examples/PostfixToInfixNotationTranslatorTest.php
@@ -18,13 +18,16 @@ class PostfixToInfixNotationTranslatorTest extends PHPUnit_Framework_TestCase
         $tree = $parser->parse($str);
 
         $tree->inPlaceTranslate('start', function ($node, $parent) {
-            if ($node->getDetailType() == 1) return;
+            if ($node->getDetailType() == 1) {
+                return;
+            }
 
             $temp = $node->getSubnode(1);
             $node->setSubnode(1, $node->getSubnode(2));
             $node->setSubnode(2, $temp);
 
-            if ($parent && in_array((string)$node->getSubnode(1), array('+', '-')) && in_array((string)$parent->getSubnode(2), array('*', '/'))) {
+            if ($parent && in_array((string)$node->getSubnode(1),
+                    array('+', '-')) && in_array((string)$parent->getSubnode(2), array('*', '/'))) {
                 return '(' . $node . ')';
             }
         });

--- a/tests/Examples/YamlLikeIndentationParserTest.php
+++ b/tests/Examples/YamlLikeIndentationParserTest.php
@@ -1,6 +1,7 @@
 <?php
 
-class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase {
+class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase
+{
     public function testBase()
     {
         $parser = new \ParserGenerator\Examples\YamlLikeIndentationParser();
@@ -8,7 +9,8 @@ class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(array("a" => "x"), $parser->getValue("a:x"));
         $this->assertEquals(array(
             "a" => "x",
-            "b" => "y"), $parser->getValue("
+            "b" => "y"
+        ), $parser->getValue("
             a:x
             b:y"));
     }
@@ -19,7 +21,9 @@ class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(array(
             "a" => array(
-                "b" => "x")), $parser->getValue("
+                "b" => "x"
+            )
+        ), $parser->getValue("
             a:
              b:x"));
     }
@@ -30,7 +34,9 @@ class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(array(
             "a" => array(
-                "b" => "x")), $parser->getValue("
+                "b" => "x"
+            )
+        ), $parser->getValue("
             a:
                          b:x"));
     }
@@ -45,7 +51,11 @@ class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase {
                     "c" => array(
                         "d" => array(
                             "e" => "x"
-            ))))), $parser->getValue("
+                        )
+                    )
+                )
+            )
+        ), $parser->getValue("
             a:
               b:
                 c:
@@ -62,7 +72,9 @@ class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase {
                 "b" => array(
                     "c" => "x",
                     "d" => "y"
-                ))), $parser->getValue("
+                )
+            )
+        ), $parser->getValue("
             a:
               b:
                 c:x
@@ -72,9 +84,10 @@ class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase {
             "a" => array(
                 "b" => array(
                     "c" => "x"
-                    ),
+                ),
                 "d" => "y"
-            )), $parser->getValue("
+            )
+        ), $parser->getValue("
             a:
               b:
                 c:x
@@ -84,9 +97,10 @@ class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase {
             "a" => array(
                 "b" => array(
                     "c" => "x"
-                )),
+                )
+            ),
             "d" => "y"
-            ), $parser->getValue("
+        ), $parser->getValue("
             a:
               b:
                 c:x
@@ -121,18 +135,20 @@ class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase {
                     "f" => array(
                         "g" => "3",
                         "h" => "4"
-                    )),
+                    )
+                ),
                 "i" => "5",
                 "j" => "6",
                 "k" => array(
                     "l" => array(
                         "m" => "7"
-                        ),
+                    ),
                     "n" => "8",
                     "o" => "9"
-                    ),
+                ),
                 "p" => "10"
-                )), $parser->getValue("
+            )
+        ), $parser->getValue("
             a:
               b:
                 c:1
@@ -150,4 +166,4 @@ class YamlLikeIndentationParserTest extends PHPUnit_Framework_TestCase {
                 o:9
               p:10"));
     }
-} 
+}

--- a/tests/Extension/ChoiceTest.php
+++ b/tests/Extension/ChoiceTest.php
@@ -29,7 +29,8 @@ class ChoiceTest extends PHPUnit_Framework_TestCase
 	                 abc   :=> "abc".');
 
         $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Branch('abc', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('abc'))),
+            new \ParserGenerator\SyntaxTreeNode\Branch('abc', 0,
+                array(new \ParserGenerator\SyntaxTreeNode\Leaf('abc'))),
             new \ParserGenerator\SyntaxTreeNode\Leaf('.'),
         )), $x->parse("abc."));
     }
@@ -55,54 +56,58 @@ class ChoiceTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
             new \ParserGenerator\SyntaxTreeNode\Series('list', '', array(
-                new \ParserGenerator\SyntaxTreeNode\Branch('a', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('b', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('a', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('b', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('a', 0,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('b', 0,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('a', 0,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('b', 0,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
                 new \ParserGenerator\SyntaxTreeNode\Branch('b', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('b')))
             ), false)
         )), $x->parse('ababb'));
     }
-	
-	public function testSeries()
-	{
-	    $x = new Parser('start :=> ("a" | "b" "c" | "c" ?"d" | "d"++) /.+/.');
-		
-		$this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+
+    public function testSeries()
+    {
+        $x = new Parser('start :=> ("a" | "b" "c" | "c" ?"d" | "d"++) /.+/.');
+
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
             new \ParserGenerator\SyntaxTreeNode\Leaf('a'),
             new \ParserGenerator\SyntaxTreeNode\Leaf('a')
         )), $x->parse('aa'));
-		
-		$this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
             new \ParserGenerator\SyntaxTreeNode\Leaf('c'),
             new \ParserGenerator\SyntaxTreeNode\Leaf('de')
         )), $x->parse('cde'));
-		
-		$parsed = $x->parse('bce');
-		$this->assertTrue((bool) $parsed->getSubnode(0)->getType());
-		$parsed->getSubnode(0)->setType('');
-		
-		$this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+
+        $parsed = $x->parse('bce');
+        $this->assertTrue((bool)$parsed->getSubnode(0)->getType());
+        $parsed->getSubnode(0)->setType('');
+
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
             new \ParserGenerator\SyntaxTreeNode\Branch('', 1, array(
-			    new \ParserGenerator\SyntaxTreeNode\Leaf('b'),
-				new \ParserGenerator\SyntaxTreeNode\Leaf('c')
-			)),
+                new \ParserGenerator\SyntaxTreeNode\Leaf('b'),
+                new \ParserGenerator\SyntaxTreeNode\Leaf('c')
+            )),
             new \ParserGenerator\SyntaxTreeNode\Leaf('e')
         )), $parsed);
-		
-		$this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
             new \ParserGenerator\SyntaxTreeNode\Series('list', 'd', array(
-			    new \ParserGenerator\SyntaxTreeNode\Leaf('d'),
-				new \ParserGenerator\SyntaxTreeNode\Leaf('d')
-			)),
+                new \ParserGenerator\SyntaxTreeNode\Leaf('d'),
+                new \ParserGenerator\SyntaxTreeNode\Leaf('d')
+            )),
             new \ParserGenerator\SyntaxTreeNode\Leaf('e')
         )), $x->parse('dde'));
-		
-		$this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
             new \ParserGenerator\SyntaxTreeNode\Series('list', 'd', array(
-			    new \ParserGenerator\SyntaxTreeNode\Leaf('d')
-			)),
+                new \ParserGenerator\SyntaxTreeNode\Leaf('d')
+            )),
             new \ParserGenerator\SyntaxTreeNode\Leaf('e')
         )), $x->parse('de'));
-	}
+    }
 }

--- a/tests/Extension/ItemRestrictions/ContainTest.php
+++ b/tests/Extension/ItemRestrictions/ContainTest.php
@@ -5,39 +5,39 @@ use ParserGenerator\Parser;
 class ContainTest extends PHPUnit_Framework_TestCase
 {
     public function test()
-	{
-	    $x = new Parser("start :=> 'abcd'
+    {
+        $x = new Parser("start :=> 'abcd'
 		                       :=> 'ab'.");
-							   
-	    $contain = new \ParserGenerator\Extension\ItemRestrictions\Contain($x->grammar['start']);
-		
-		$this->assertFalse($contain->check('qwerty', 0, 3, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('abcdef', 0, 6, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('aabcdef', 0, 7, null));
-		$x->cache = array();
-		$this->assertFalse($contain->check('abcdef', 1, 6, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('aabcdef', 1, 7, null));
-		$x->cache = array();
-		$this->assertFalse($contain->check('abcdef', 0, 1, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('abcd', 0, 3, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('ab', 0, 2, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('ab   ', 0, 5, null));
-		
-		$x = new Parser("start :=> 'abcd'
+
+        $contain = new \ParserGenerator\Extension\ItemRestrictions\Contain($x->grammar['start']);
+
+        $this->assertFalse($contain->check('qwerty', 0, 3, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('abcdef', 0, 6, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('aabcdef', 0, 7, null));
+        $x->cache = array();
+        $this->assertFalse($contain->check('abcdef', 1, 6, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('aabcdef', 1, 7, null));
+        $x->cache = array();
+        $this->assertFalse($contain->check('abcdef', 0, 1, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('abcd', 0, 3, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('ab', 0, 2, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('ab   ', 0, 5, null));
+
+        $x = new Parser("start :=> 'abcd'
 		                       :=> 'ab'.", array('ignoreWhitespaces' => true));
-							   
-	    $contain = new \ParserGenerator\Extension\ItemRestrictions\Contain($x->grammar['start']);
-		
-		$this->assertTrue($contain->check('ab  ', 0, 4, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('ab  ', 0, 3, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('ab  ', 0, 2, null));
-	}
+
+        $contain = new \ParserGenerator\Extension\ItemRestrictions\Contain($x->grammar['start']);
+
+        $this->assertTrue($contain->check('ab  ', 0, 4, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('ab  ', 0, 3, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('ab  ', 0, 2, null));
+    }
 }

--- a/tests/Extension/ItemRestrictions/IsTest.php
+++ b/tests/Extension/ItemRestrictions/IsTest.php
@@ -5,38 +5,38 @@ use ParserGenerator\Parser;
 class IsTest extends PHPUnit_Framework_TestCase
 {
     public function test()
-	{
-	    $x = new Parser("start :=> 'abcd'
+    {
+        $x = new Parser("start :=> 'abcd'
 		                       :=> 'ab'.");
-							   
-	    $contain = new \ParserGenerator\Extension\ItemRestrictions\Is($x->grammar['start']);
-		
-		$this->assertFalse($contain->check('qwerty', 0, 3, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('xabcd', 1, 5, null));
-		$x->cache = array();
-		$this->assertFalse($contain->check('xabcf', 1, 5, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('xabcf', 1, 3, null));
-		$x->cache = array();
-		$this->assertFalse($contain->check('xabcd', 1, 4, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('ab', 0, 2, null));
-		$x->cache = array();
-		$this->assertTrue($contain->check('ab  ', 0, 2, null));
-		$x->cache = array();
-		
-		$x = new Parser("start :=> 'abcd'
+
+        $contain = new \ParserGenerator\Extension\ItemRestrictions\Is($x->grammar['start']);
+
+        $this->assertFalse($contain->check('qwerty', 0, 3, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('xabcd', 1, 5, null));
+        $x->cache = array();
+        $this->assertFalse($contain->check('xabcf', 1, 5, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('xabcf', 1, 3, null));
+        $x->cache = array();
+        $this->assertFalse($contain->check('xabcd', 1, 4, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('ab', 0, 2, null));
+        $x->cache = array();
+        $this->assertTrue($contain->check('ab  ', 0, 2, null));
+        $x->cache = array();
+
+        $x = new Parser("start :=> 'abcd'
 		                       :=> 'ab'.", array('ignoreWhitespaces' => true));
-							   
-	    $contain = new \ParserGenerator\Extension\ItemRestrictions\Is($x->grammar['start']);
-		
-		$this->assertTrue($contain->check('ab  ', 0, 4, null));
-		
-		// I dont realy know what to return in these cases
-		//$x->cache = array();
-		//$this->assertTrue($contain->check('ab  ', 0, 3, null));
-		//$x->cache = array();
-		//$this->assertTrue($contain->check('ab  ', 0, 2, null));
-	}
+
+        $contain = new \ParserGenerator\Extension\ItemRestrictions\Is($x->grammar['start']);
+
+        $this->assertTrue($contain->check('ab  ', 0, 4, null));
+
+        // I dont realy know what to return in these cases
+        //$x->cache = array();
+        //$this->assertTrue($contain->check('ab  ', 0, 3, null));
+        //$x->cache = array();
+        //$this->assertTrue($contain->check('ab  ', 0, 2, null));
+    }
 }

--- a/tests/Extension/ItemRestrictionsTest.php
+++ b/tests/Extension/ItemRestrictionsTest.php
@@ -2,12 +2,9 @@
 
 namespace ParserGenerator\Tests\Extension;
 
-use ParserGenerator\SyntaxTreeNode\Root;
-use ParserGenerator\SyntaxTreeNode\Branch;
-use ParserGenerator\SyntaxTreeNode\Leaf;
-use ParserGenerator\SyntaxTreeNode\Series;
-
 use ParserGenerator\Parser;
+use ParserGenerator\SyntaxTreeNode\Leaf;
+use ParserGenerator\SyntaxTreeNode\Root;
 
 class ItemRestrictionsTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,266 +18,267 @@ class ItemRestrictionsTest extends \PHPUnit_Framework_TestCase
         $x = new Parser('start :=> text contain "aa".');
 
         $this->assertFalse($x->parse('bcd'));
-		$this->assertFalse($x->parse('acba'));
-		$this->assertFalse($x->parse('a'));
-		$this->assertObject($x->parse('aa'));
-		$this->assertObject($x->parse('aabcdef'));
-		$this->assertObject($x->parse('bcaadef'));
-		$this->assertObject($x->parse('bcdefaa'));
-		$this->assertObject($x->parse('bcaadeaaf'));
-		$this->assertObject($x->parse('bcdaaaef'));
-		
-		$x = new Parser('start :=> text contain /[ab]{2}/ "b".');
+        $this->assertFalse($x->parse('acba'));
+        $this->assertFalse($x->parse('a'));
+        $this->assertObject($x->parse('aa'));
+        $this->assertObject($x->parse('aabcdef'));
+        $this->assertObject($x->parse('bcaadef'));
+        $this->assertObject($x->parse('bcdefaa'));
+        $this->assertObject($x->parse('bcaadeaaf'));
+        $this->assertObject($x->parse('bcdaaaef'));
+
+        $x = new Parser('start :=> text contain /[ab]{2}/ "b".');
 
         $this->assertFalse($x->parse('bbcd'));
-		$this->assertFalse($x->parse('acbaa'));
-		$this->assertFalse($x->parse('a'));
-		$this->assertFalse($x->parse(''));
-		$this->assertFalse($x->parse('aac'));
-		$this->assertFalse($x->parse('ab'));
-		
-		$this->assertEquals(new Root('start', 0, array(
-            new Leaf("aa"),
-			new Leaf("b")
-        )), $x->parse("aab"));
-		
-		$this->assertEquals(new Root('start', 0, array(
-            new Leaf("sdabag"),
-			new Leaf("b")
-        )), $x->parse("sdabagb"));
-		
-		$this->assertEquals(new Root('start', 0, array(
-            new Leaf("ba"),
-			new Leaf("b")
-        )), $x->parse("bab"));
-		
-		$x = new Parser('start :=> text contain /[ab]{2}/ text.');
-		
-		$this->assertFalse($x->parse('bcd'));
-		$this->assertFalse($x->parse('b'));
-		$this->assertFalse($x->parse('a'));
-		$this->assertFalse($x->parse(''));
+        $this->assertFalse($x->parse('acbaa'));
+        $this->assertFalse($x->parse('a'));
+        $this->assertFalse($x->parse(''));
+        $this->assertFalse($x->parse('aac'));
+        $this->assertFalse($x->parse('ab'));
 
-		$this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, array(
+            new Leaf("aa"),
+            new Leaf("b")
+        )), $x->parse("aab"));
+
+        $this->assertEquals(new Root('start', 0, array(
+            new Leaf("sdabag"),
+            new Leaf("b")
+        )), $x->parse("sdabagb"));
+
+        $this->assertEquals(new Root('start', 0, array(
             new Leaf("ba"),
-			new Leaf("b")
+            new Leaf("b")
         )), $x->parse("bab"));
-		
-		$this->assertEquals(new Root('start', 0, array(
+
+        $x = new Parser('start :=> text contain /[ab]{2}/ text.');
+
+        $this->assertFalse($x->parse('bcd'));
+        $this->assertFalse($x->parse('b'));
+        $this->assertFalse($x->parse('a'));
+        $this->assertFalse($x->parse(''));
+
+        $this->assertEquals(new Root('start', 0, array(
+            new Leaf("ba"),
+            new Leaf("b")
+        )), $x->parse("bab"));
+
+        $this->assertEquals(new Root('start', 0, array(
             new Leaf("xba"),
-			new Leaf("bb")
+            new Leaf("bb")
         )), $x->parse("xbabb"));
-		
-		$this->assertEquals(new Root('start', 0, array(
+
+        $this->assertEquals(new Root('start', 0, array(
             new Leaf("xba"),
-			new Leaf("xbbxaa")
+            new Leaf("xbbxaa")
         )), $x->parse("xbaxbbxaa"));
     }
-	
-	public function testWithNodes() {
-	    $x = new Parser('start           :=> text contain textInBranckets.
+
+    public function testWithNodes()
+    {
+        $x = new Parser('start           :=> text contain textInBranckets.
 		                 textInBranckets :=> "(" text ")"
 						                 :=> "[" text "]".');
-		
-		$this->assertFalse($x->parse('asdg'));
-		$this->assertFalse($x->parse(''));
-		$this->assertFalse($x->parse('as(sd'));
-		$this->assertFalse($x->parse('as[sd'));
-		$this->assertFalse($x->parse('[asd'));
-		$this->assertFalse($x->parse('['));
-		$this->assertFalse($x->parse('a[df[gdd(fsd(df'));
-		$this->assertFalse($x->parse('as[d)g'));
-		$this->assertFalse($x->parse('as(d]g'));
-		$this->assertFalse($x->parse('d]dsf[d'));
-		$this->assertObject($x->parse('as[d]g'));
-		$this->assertObject($x->parse('as(d)g'));
-		$this->assertObject($x->parse('as[[)]g'));
-		$this->assertObject($x->parse('[]aaa'));
-		$this->assertObject($x->parse('aaa[]'));
-		$this->assertFalse($x->parse('as['));
-		$this->assertFalse($x->parse(']as'));
-		$this->assertObject($x->parse('sd[ss ]dg[sdf]g'));
-		$this->assertObject($x->parse('()'));
-		$this->assertObject($x->parse('[asdd]'));
-		$this->assertObject($x->parse(']df[asdd]gg['));
-		$this->assertObject($x->parse(']()['));
-		$this->assertObject($x->parse('[)(]('));
-	}
-	
-	public function testNot()
-	{
-	    $x = new Parser('start :=> text not contain "aa".');
+
+        $this->assertFalse($x->parse('asdg'));
+        $this->assertFalse($x->parse(''));
+        $this->assertFalse($x->parse('as(sd'));
+        $this->assertFalse($x->parse('as[sd'));
+        $this->assertFalse($x->parse('[asd'));
+        $this->assertFalse($x->parse('['));
+        $this->assertFalse($x->parse('a[df[gdd(fsd(df'));
+        $this->assertFalse($x->parse('as[d)g'));
+        $this->assertFalse($x->parse('as(d]g'));
+        $this->assertFalse($x->parse('d]dsf[d'));
+        $this->assertObject($x->parse('as[d]g'));
+        $this->assertObject($x->parse('as(d)g'));
+        $this->assertObject($x->parse('as[[)]g'));
+        $this->assertObject($x->parse('[]aaa'));
+        $this->assertObject($x->parse('aaa[]'));
+        $this->assertFalse($x->parse('as['));
+        $this->assertFalse($x->parse(']as'));
+        $this->assertObject($x->parse('sd[ss ]dg[sdf]g'));
+        $this->assertObject($x->parse('()'));
+        $this->assertObject($x->parse('[asdd]'));
+        $this->assertObject($x->parse(']df[asdd]gg['));
+        $this->assertObject($x->parse(']()['));
+        $this->assertObject($x->parse('[)(]('));
+    }
+
+    public function testNot()
+    {
+        $x = new Parser('start :=> text not contain "aa".');
 
         $this->assertObject($x->parse('bcd'));
-		$this->assertObject($x->parse('acba'));
-		$this->assertObject($x->parse('a'));
-		$this->assertFalse($x->parse('aa'));
-		$this->assertFalse($x->parse('aabcdef'));
-		$this->assertFalse($x->parse('bcaadef'));
-		$this->assertFalse($x->parse('bcdefaa'));
-		$this->assertFalse($x->parse('bcaadeaaf'));
-		$this->assertFalse($x->parse('bcdaaaef'));
-	}
-	
-	public function testLogicConditionsOr()
-	{	
-		$x = new Parser('start :=> text contain "a" or contain "b".');
-		
-		$this->assertFalse($x->parse('c'));
-		$this->assertObject($x->parse('a'));
-		$this->assertObject($x->parse('b'));
-		$this->assertObject($x->parse('ab'));
-		
-		$x = new Parser('start :=> text contain "a" or contain "b" or contain "c".');
-		
-		$this->assertFalse($x->parse('d'));
-		$this->assertObject($x->parse('a'));
-		$this->assertObject($x->parse('b'));
-		$this->assertObject($x->parse('ac'));
-		$this->assertObject($x->parse('c'));
-		$this->assertObject($x->parse('cab'));
-		
-		$x = new Parser('start :=> text contain "a" or not contain "b".');
-		
-		$this->assertFalse($x->parse('b'));
-		$this->assertFalse($x->parse('erbbt'));
-		$this->assertObject($x->parse(''));
-		$this->assertObject($x->parse('rtyh'));
-		$this->assertObject($x->parse('ab'));
-		$this->assertObject($x->parse('ac'));
-	}
-	
-	public function testLogicConditionsAnd()
-	{
-		$x = new Parser('start :=> text contain "a" and contain "b".');
-		
-		$this->assertFalse($x->parse('c'));
-		$this->assertFalse($x->parse('a'));
-		$this->assertFalse($x->parse('b'));
-		$this->assertObject($x->parse('ab'));
-		
-		$x = new Parser('start :=> text contain "a" and contain "b" and contain "c".');
-		
-		$this->assertFalse($x->parse('d'));
-		$this->assertFalse($x->parse('a'));
-		$this->assertFalse($x->parse('b'));
-		$this->assertFalse($x->parse('ac'));
-		$this->assertFalse($x->parse('c'));
-		$this->assertObject($x->parse('cab'));
-		
-		$x = new Parser('start :=> text contain "a" and not contain "b".');
-		
-		$this->assertFalse($x->parse('b'));
-		$this->assertFalse($x->parse('erbbt'));
-		$this->assertFalse($x->parse(''));
-		$this->assertFalse($x->parse('rtyh'));
-		$this->assertFalse($x->parse('ab'));
-		$this->assertObject($x->parse('ac'));
-	}
-	
-	public function testLogicConditionsGroups()
-	{
-		$x = new Parser('start :=> text (contain "a" and not contain "b") or (not contain "a" and contain "b").');
-		
-		$this->assertFalse($x->parse('c'));
-		$this->assertObject($x->parse('a'));
-		$this->assertObject($x->parse('b'));
-		$this->assertFalse($x->parse('ab'));
-		
-		$x = new Parser('start :=> text contain "c" and (contain "b" or contain "a").');
-		
-		$this->assertFalse($x->parse('c'));
-		$this->assertObject($x->parse('ca'));
-		$this->assertObject($x->parse('cb'));
-		$this->assertObject($x->parse('cab'));
-		$this->assertFalse($x->parse(''));
-		$this->assertFalse($x->parse('a'));
-		$this->assertFalse($x->parse('b'));
-		$this->assertFalse($x->parse('ab'));
-	}
-	
-	public function testWithLookaroundSimple()
-	{
-		$x = new Parser('start :=> (text contain ?"aaa") text.');
-		
-		$this->assertEquals(new Root('start', 0, array(
+        $this->assertObject($x->parse('acba'));
+        $this->assertObject($x->parse('a'));
+        $this->assertFalse($x->parse('aa'));
+        $this->assertFalse($x->parse('aabcdef'));
+        $this->assertFalse($x->parse('bcaadef'));
+        $this->assertFalse($x->parse('bcdefaa'));
+        $this->assertFalse($x->parse('bcaadeaaf'));
+        $this->assertFalse($x->parse('bcdaaaef'));
+    }
+
+    public function testLogicConditionsOr()
+    {
+        $x = new Parser('start :=> text contain "a" or contain "b".');
+
+        $this->assertFalse($x->parse('c'));
+        $this->assertObject($x->parse('a'));
+        $this->assertObject($x->parse('b'));
+        $this->assertObject($x->parse('ab'));
+
+        $x = new Parser('start :=> text contain "a" or contain "b" or contain "c".');
+
+        $this->assertFalse($x->parse('d'));
+        $this->assertObject($x->parse('a'));
+        $this->assertObject($x->parse('b'));
+        $this->assertObject($x->parse('ac'));
+        $this->assertObject($x->parse('c'));
+        $this->assertObject($x->parse('cab'));
+
+        $x = new Parser('start :=> text contain "a" or not contain "b".');
+
+        $this->assertFalse($x->parse('b'));
+        $this->assertFalse($x->parse('erbbt'));
+        $this->assertObject($x->parse(''));
+        $this->assertObject($x->parse('rtyh'));
+        $this->assertObject($x->parse('ab'));
+        $this->assertObject($x->parse('ac'));
+    }
+
+    public function testLogicConditionsAnd()
+    {
+        $x = new Parser('start :=> text contain "a" and contain "b".');
+
+        $this->assertFalse($x->parse('c'));
+        $this->assertFalse($x->parse('a'));
+        $this->assertFalse($x->parse('b'));
+        $this->assertObject($x->parse('ab'));
+
+        $x = new Parser('start :=> text contain "a" and contain "b" and contain "c".');
+
+        $this->assertFalse($x->parse('d'));
+        $this->assertFalse($x->parse('a'));
+        $this->assertFalse($x->parse('b'));
+        $this->assertFalse($x->parse('ac'));
+        $this->assertFalse($x->parse('c'));
+        $this->assertObject($x->parse('cab'));
+
+        $x = new Parser('start :=> text contain "a" and not contain "b".');
+
+        $this->assertFalse($x->parse('b'));
+        $this->assertFalse($x->parse('erbbt'));
+        $this->assertFalse($x->parse(''));
+        $this->assertFalse($x->parse('rtyh'));
+        $this->assertFalse($x->parse('ab'));
+        $this->assertObject($x->parse('ac'));
+    }
+
+    public function testLogicConditionsGroups()
+    {
+        $x = new Parser('start :=> text (contain "a" and not contain "b") or (not contain "a" and contain "b").');
+
+        $this->assertFalse($x->parse('c'));
+        $this->assertObject($x->parse('a'));
+        $this->assertObject($x->parse('b'));
+        $this->assertFalse($x->parse('ab'));
+
+        $x = new Parser('start :=> text contain "c" and (contain "b" or contain "a").');
+
+        $this->assertFalse($x->parse('c'));
+        $this->assertObject($x->parse('ca'));
+        $this->assertObject($x->parse('cb'));
+        $this->assertObject($x->parse('cab'));
+        $this->assertFalse($x->parse(''));
+        $this->assertFalse($x->parse('a'));
+        $this->assertFalse($x->parse('b'));
+        $this->assertFalse($x->parse('ab'));
+    }
+
+    public function testWithLookaroundSimple()
+    {
+        $x = new Parser('start :=> (text contain ?"aaa") text.');
+
+        $this->assertEquals(new Root('start', 0, array(
             new Leaf("qaaba"),
-			new Leaf("aacaaaa")
+            new Leaf("aacaaaa")
         )), $x->parse("qaabaaacaaaa"));
-	}
-	
-	public function testWithLookaround()
-	{
-	    /* Lets define grammar where: 
-		 * text where all "<<<" are closed with ">>>"
-		 * free "<<<" or ">>>" are forbidden.
-		 * without "not contain ..." string "<<<" would be parsed as well
-		 */
-	    $x = new Parser('start     :=> properText+tag.
+    }
+
+    public function testWithLookaround()
+    {
+        /* Lets define grammar where:
+         * text where all "<<<" are closed with ">>>"
+         * free "<<<" or ">>>" are forbidden.
+         * without "not contain ..." string "<<<" would be parsed as well
+         */
+        $x = new Parser('start     :=> properText+tag.
 		                 tag       :=> open properText close.
 						 properText:=> text not contain ?(open|close).
 						 open      :=> "<<<".
 						 close     :=> ">>>".');
-	    
-		$this->assertObject($x->parse("asd<<<asdfg>>>fsdf"));
-		$this->assertObject($x->parse("as>d<<<as<<dfg>>>fsd><<f"));
-		$this->assertFalse($x->parse("a<<<b"));
-	}
-	
-	public function testIsBasic()
-	{
-	    $x = new Parser('start :=> text is "expected text".');
-		
-		$this->assertFalse($x->parse("random text"));
-		$this->assertFalse($x->parse(""));
-		$this->assertFalse($x->parse("expected"));
-		$this->assertFalse($x->parse("text"));
-		$this->assertObject($x->parse("expected text"));
-	}
-	
-	public function testIsWithRegex()
-	{
-	    //matches only text containing exactly two letters "a" and five letters "b" in any order
-		$x = new Parser('start :=> /([^a]*a){2}[^a]*/ is /([^b]*b){5}[^b]*/ is /[ab]+/.');
-		
-		$this->assertFalse($x->parse(''));
-		$this->assertFalse($x->parse('aa'));
-		$this->assertFalse($x->parse('bbbbb'));
-		$this->assertObject($x->parse('aabbbbb'));
-		$this->assertObject($x->parse('bbbbbaa'));
-		$this->assertFalse($x->parse('aacbbbbb'));
-		$this->assertFalse($x->parse('aaabbbbb'));
-		$this->assertFalse($x->parse('aabbbbbb'));
-		$this->assertObject($x->parse('bbaabbb'));
-		$this->assertObject($x->parse('bbabbab'));
-	}
-	
-	public function testIsWithNot()
-	{
-	    $x = new Parser('start :=> text not is ("forbidden"|"words").');
 
-		$this->assertObject($x->parse("asdf"));
-		$this->assertObject($x->parse("keywords"));
-		$this->assertObject($x->parse("word"));
-		$this->assertObject($x->parse("xforbidden"));
-		$this->assertFalse($x->parse("words"));
-		$this->assertFalse($x->parse("forbidden"));
-	}
-	
-	public function testFollowedBy()
-	{
-	    //TODO:
-	    return 0;
-	    $x = new Parser('start :=> text followed by "a" text.');
-		
-		$this->assertEquals(new Root('start', 0, array(
+        $this->assertObject($x->parse("asd<<<asdfg>>>fsdf"));
+        $this->assertObject($x->parse("as>d<<<as<<dfg>>>fsd><<f"));
+        $this->assertFalse($x->parse("a<<<b"));
+    }
+
+    public function testIsBasic()
+    {
+        $x = new Parser('start :=> text is "expected text".');
+
+        $this->assertFalse($x->parse("random text"));
+        $this->assertFalse($x->parse(""));
+        $this->assertFalse($x->parse("expected"));
+        $this->assertFalse($x->parse("text"));
+        $this->assertObject($x->parse("expected text"));
+    }
+
+    public function testIsWithRegex()
+    {
+        //matches only text containing exactly two letters "a" and five letters "b" in any order
+        $x = new Parser('start :=> /([^a]*a){2}[^a]*/ is /([^b]*b){5}[^b]*/ is /[ab]+/.');
+
+        $this->assertFalse($x->parse(''));
+        $this->assertFalse($x->parse('aa'));
+        $this->assertFalse($x->parse('bbbbb'));
+        $this->assertObject($x->parse('aabbbbb'));
+        $this->assertObject($x->parse('bbbbbaa'));
+        $this->assertFalse($x->parse('aacbbbbb'));
+        $this->assertFalse($x->parse('aaabbbbb'));
+        $this->assertFalse($x->parse('aabbbbbb'));
+        $this->assertObject($x->parse('bbaabbb'));
+        $this->assertObject($x->parse('bbabbab'));
+    }
+
+    public function testIsWithNot()
+    {
+        $x = new Parser('start :=> text not is ("forbidden"|"words").');
+
+        $this->assertObject($x->parse("asdf"));
+        $this->assertObject($x->parse("keywords"));
+        $this->assertObject($x->parse("word"));
+        $this->assertObject($x->parse("xforbidden"));
+        $this->assertFalse($x->parse("words"));
+        $this->assertFalse($x->parse("forbidden"));
+    }
+
+    public function testFollowedBy()
+    {
+        //TODO:
+        return 0;
+        $x = new Parser('start :=> text followed by "a" text.');
+
+        $this->assertEquals(new Root('start', 0, array(
             new Leaf("qw"),
-			new Leaf("adgahaab")
+            new Leaf("adgahaab")
         )), $x->parse("qwadgahaab"));
-		
-		$this->assertEquals(new Root('start', 0, array(
+
+        $this->assertEquals(new Root('start', 0, array(
             new Leaf(""),
-			new Leaf("aaa")
+            new Leaf("aaa")
         )), $x->parse("aaa"));
-	}
+    }
 }

--- a/tests/Extension/LookaheadTest.php
+++ b/tests/Extension/LookaheadTest.php
@@ -113,27 +113,28 @@ class LookaheadTest extends \PHPUnit_Framework_TestCase
         )), $x->parse("abce"));
     }
 
-    
-    public function testAnBnCnGrammar() {
+
+    public function testAnBnCnGrammar()
+    {
         $x = new Parser('start :=> ?(A "c") "a"++ B.
                          A     :=> "a" A? "b".
                          B     :=> "b" B? "c".');
-						 
-	    $this->assertObject($x->parse('abc'));
-		$this->assertObject($x->parse('aabbcc'));
-		$this->assertObject($x->parse('aaabbbccc'));
-		
-		$this->assertFalse($x->parse('aabb'));
-		$this->assertFalse($x->parse('aacc'));
-		$this->assertFalse($x->parse('bbcc'));
-		
-		$this->assertFalse($x->parse('aabbc'));
-		$this->assertFalse($x->parse('aabcc'));
-		$this->assertFalse($x->parse('abbcc'));
-		
-		$this->assertFalse($x->parse('aabbccc'));
-		$this->assertFalse($x->parse('aabbbcc'));
-		$this->assertFalse($x->parse('aaabbcc'));
+
+        $this->assertObject($x->parse('abc'));
+        $this->assertObject($x->parse('aabbcc'));
+        $this->assertObject($x->parse('aaabbbccc'));
+
+        $this->assertFalse($x->parse('aabb'));
+        $this->assertFalse($x->parse('aacc'));
+        $this->assertFalse($x->parse('bbcc'));
+
+        $this->assertFalse($x->parse('aabbc'));
+        $this->assertFalse($x->parse('aabcc'));
+        $this->assertFalse($x->parse('abbcc'));
+
+        $this->assertFalse($x->parse('aabbccc'));
+        $this->assertFalse($x->parse('aabbbcc'));
+        $this->assertFalse($x->parse('aaabbcc'));
     }
 
     public function testErrorTrack()

--- a/tests/Extension/ParametrizedNodeTest.php
+++ b/tests/Extension/ParametrizedNodeTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use ParserGenerator\Parser;
-use ParserGenerator\SyntaxTreeNode\Branch;
-use ParserGenerator\SyntaxTreeNode\Root;
-use ParserGenerator\SyntaxTreeNode\Leaf;
 
 class ParametrizedNodeTest extends PHPUnit_Framework_TestCase
 {
@@ -156,7 +153,7 @@ class ParametrizedNodeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array("1010", "11"), $toList("101011"));
         $this->assertEquals(array("10110101", "0010"), $toList("101101010010"));
         $this->assertEquals(array("1001001111", "11011", "1011100"), $toList("1001001111110111011100"));
-        $this->assertEquals(array("11111101111010"),     $toList("11111101111010"));
+        $this->assertEquals(array("11111101111010"), $toList("11111101111010"));
         $this->assertEquals(array("1111110111", "1110"), $toList("11111101111110"));
 
         $this->assertFalse($x->parse("0000000000000"));

--- a/tests/Extension/PredefinedStringTest.php
+++ b/tests/Extension/PredefinedStringTest.php
@@ -4,14 +4,16 @@ namespace ParserGenerator\Tests\Extension;
 
 use ParserGenerator\Parser;
 
-class StringTest extends \PHPUnit_Framework_TestCase {
+class StringTest extends \PHPUnit_Framework_TestCase
+{
 
     protected function assertObject($a)
     {
         $this->assertTrue(is_object($a));
     }
 
-    public function testSimple() {
+    public function testSimple()
+    {
         $x = new Parser('start :=> string.');
 
         $this->assertObject($x->parse('"asd\\" "'));

--- a/tests/Extension/RuleConditionTest.php
+++ b/tests/Extension/RuleConditionTest.php
@@ -13,7 +13,8 @@ class RuleConditionTest extends \PHPUnit_Framework_TestCase
 
     public function testIntegers()
     {
-        $x = new Parser('start :=> 1..100 1..100 <? $s[0]->getValue() < $s[1]->getValue() ?>.', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> 1..100 1..100 <? $s[0]->getValue() < $s[1]->getValue() ?>.',
+            array('ignoreWhitespaces' => true));
         $this->assertObject($x->parse('36 45'));
         $this->assertObject($x->parse('1 100'));
         $this->assertObject($x->parse('1 2'));

--- a/tests/Extension/SeriesTest.php
+++ b/tests/Extension/SeriesTest.php
@@ -27,11 +27,16 @@ class SeriesTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
             new \ParserGenerator\SyntaxTreeNode\Series('list', 'str', array(
-                new \ParserGenerator\SyntaxTreeNode\Branch('str', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('str', 1, array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('str', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('str', 2, array(new \ParserGenerator\SyntaxTreeNode\Leaf('c'))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('str', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('str', 0,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('str', 1,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('str', 0,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('str', 2,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('c'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('str', 0,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
             ), false)
         )), $x->parse("abaca"));
     }
@@ -69,11 +74,16 @@ class SeriesTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
             new \ParserGenerator\SyntaxTreeNode\Series('list', 'str', array(
-                new \ParserGenerator\SyntaxTreeNode\Branch('str', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('coma', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf(','))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('str', 2, array(new \ParserGenerator\SyntaxTreeNode\Leaf('c'))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('coma', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf(','))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('str', 1, array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('str', 0,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('coma', 0,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf(','))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('str', 2,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('c'))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('coma', 0,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf(','))),
+                new \ParserGenerator\SyntaxTreeNode\Branch('str', 1,
+                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
             ), true)
         )), $x->parse("a,c,b"));
     }

--- a/tests/Extension/TextTest.php
+++ b/tests/Extension/TextTest.php
@@ -2,12 +2,10 @@
 
 namespace ParserGenerator\Tests\Extension;
 
-use ParserGenerator\SyntaxTreeNode\Root;
-use ParserGenerator\SyntaxTreeNode\Branch;
-use ParserGenerator\SyntaxTreeNode\Leaf;
-use ParserGenerator\SyntaxTreeNode\Series;
-
 use ParserGenerator\Parser;
+use ParserGenerator\SyntaxTreeNode\Leaf;
+use ParserGenerator\SyntaxTreeNode\Root;
+use ParserGenerator\SyntaxTreeNode\Series;
 
 class TextTest extends \PHPUnit_Framework_TestCase
 {
@@ -23,22 +21,22 @@ class TextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new Root('start', 0, array(
             new Leaf("Lorem ipsum dolor\nsit emet")
         )), $x->parse("Lorem ipsum dolor\nsit emet"));
-		
-		$this->assertEquals(new Root('start', 0, array(
+
+        $this->assertEquals(new Root('start', 0, array(
             new Leaf("")
         ), ' '), $x->parse(" "));
-		
-		$this->assertEquals(new Root('start', 0, array(
+
+        $this->assertEquals(new Root('start', 0, array(
             new Leaf("")
         )), $x->parse(""));
 
         $this->assertEquals(new Root('start', 0, array(
             new Leaf("Lorem ipsum", "\n")
         ), ' '), $x->parse(" Lorem ipsum\n"));
-		
-		$x = new Parser('start :=> text.', array('ignoreWhitespaces' => false));
-		
-		$this->assertEquals(new Root('start', 0, array(
+
+        $x = new Parser('start :=> text.', array('ignoreWhitespaces' => false));
+
+        $this->assertEquals(new Root('start', 0, array(
             new Leaf("")
         )), $x->parse(""));
 
@@ -46,14 +44,14 @@ class TextTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(new Root('start', 0, array(
             new Series('list', 'text', array(
-            	new Leaf('some text', ' '),
-            	new Leaf(',', ' '),
-            	new Leaf('more text')
+                new Leaf('some text', ' '),
+                new Leaf(',', ' '),
+                new Leaf('more text')
             ), true)
         )), $x->parse("some text , more text"));
-		
-		$parsed = $x->parse("a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a");
-		
-		$this->assertEquals(31, count($parsed->getSubnode(0)->getSubnodes()));
+
+        $parsed = $x->parse("a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a");
+
+        $this->assertEquals(31, count($parsed->getSubnode(0)->getSubnodes()));
     }
 }

--- a/tests/Extension/TimeTest.php
+++ b/tests/Extension/TimeTest.php
@@ -59,6 +59,7 @@ class TimeTest extends \PHPUnit_Framework_TestCase
         $x = new Parser('start :=> time(Y-m-d) text.', array('ignoreWhitespaces' => true));
 
         $timeNode = $x->parse('2014-03-08  lorem ipsum')->getSubnode(0);
-        $this->assertEquals('2014-03-08  ', $timeNode->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
+        $this->assertEquals('2014-03-08  ',
+            $timeNode->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
     }
-} 
+}

--- a/tests/GrammarNodes/GrammarNodeNumericTest.php
+++ b/tests/GrammarNodes/GrammarNodeNumericTest.php
@@ -33,7 +33,12 @@ class GrammarNodeNumericTest extends PHPUnit_Framework_TestCase
 
     public function testMinMax()
     {
-        $x = new \ParserGenerator\GrammarNode\Numeric(array('formatHex' => true, 'formatBin' => true, 'min' => 7, 'max' => 250));
+        $x = new \ParserGenerator\GrammarNode\Numeric(array(
+            'formatHex' => true,
+            'formatBin' => true,
+            'min' => 7,
+            'max' => 250
+        ));
 
         $this->assertFalse($x->rparse('-8', 0, array()));
         $this->assertFalse($x->rparse('6', 0, array()));

--- a/tests/ParsedNodes/BranchTest.php
+++ b/tests/ParsedNodes/BranchTest.php
@@ -6,11 +6,10 @@
  * Time: 12:32
  */
 
-use ParserGenerator\Parser;
 use ParserGenerator\SyntaxTreeNode\Branch;
-use ParserGenerator\SyntaxTreeNode\Root;
-use ParserGenerator\SyntaxTreeNode\Numeric;
 use ParserGenerator\SyntaxTreeNode\Leaf;
+use ParserGenerator\SyntaxTreeNode\Numeric;
+use ParserGenerator\SyntaxTreeNode\Root;
 
 class BranchTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/ParsedNodes/ParserNodeTest.php
+++ b/tests/ParsedNodes/ParserNodeTest.php
@@ -8,7 +8,8 @@ class ParserNodeTest extends PHPUnit_Framework_TestCase
             new \ParserGenerator\SyntaxTreeNode\Branch('q', 'w', array(
                 new \ParserGenerator\SyntaxTreeNode\Leaf('l1')
             )),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('l2')));
+            new \ParserGenerator\SyntaxTreeNode\Leaf('l2')
+        ));
 
         $b = clone $a;
 
@@ -25,7 +26,8 @@ class ParserNodeTest extends PHPUnit_Framework_TestCase
             new \ParserGenerator\SyntaxTreeNode\Branch('q', 'w', array(
                 new \ParserGenerator\SyntaxTreeNode\Leaf('l1')
             )),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('l2')));
+            new \ParserGenerator\SyntaxTreeNode\Leaf('l2')
+        ));
 
         $this->assertEquals('l1l2', (string)$a);
 
@@ -48,7 +50,8 @@ class ParserNodeTest extends PHPUnit_Framework_TestCase
             new \ParserGenerator\SyntaxTreeNode\Branch('q', 'w', array(
                 new \ParserGenerator\SyntaxTreeNode\Leaf('l1')
             )),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('l2')));
+            new \ParserGenerator\SyntaxTreeNode\Leaf('l2')
+        ));
 
         $b = clone $a;
 
@@ -57,25 +60,29 @@ class ParserNodeTest extends PHPUnit_Framework_TestCase
         $b->getSubnode(0)->setType('qq');
 
         $this->assertFalse($a->compare($b));
-        $this->assertTrue($a->compare($b, \ParserGenerator\SyntaxTreeNode\Base::COMPARE_DEFAULT xor \ParserGenerator\SyntaxTreeNode\Base::COMPARE_CHILDREN_NORMAL));
+        $this->assertTrue($a->compare($b,
+            \ParserGenerator\SyntaxTreeNode\Base::COMPARE_DEFAULT xor \ParserGenerator\SyntaxTreeNode\Base::COMPARE_CHILDREN_NORMAL));
 
         $b = clone $a;
         $b->setDetailType('');
 
         $this->assertFalse($a->compare($b));
-        $this->assertTrue($a->compare($b, \ParserGenerator\SyntaxTreeNode\Base::COMPARE_DEFAULT xor \ParserGenerator\SyntaxTreeNode\Base::COMPARE_SUBTYPE));
+        $this->assertTrue($a->compare($b,
+            \ParserGenerator\SyntaxTreeNode\Base::COMPARE_DEFAULT xor \ParserGenerator\SyntaxTreeNode\Base::COMPARE_SUBTYPE));
 
         $b = clone $a;
         $b->setType('');
 
         $this->assertFalse($a->compare($b));
-        $this->assertTrue($a->compare($b, \ParserGenerator\SyntaxTreeNode\Base::COMPARE_DEFAULT xor \ParserGenerator\SyntaxTreeNode\Base::COMPARE_TYPE));
+        $this->assertTrue($a->compare($b,
+            \ParserGenerator\SyntaxTreeNode\Base::COMPARE_DEFAULT xor \ParserGenerator\SyntaxTreeNode\Base::COMPARE_TYPE));
 
         $b = clone $a;
         $b->getSubnode(0)->getSubnode(0)->setContent('lx');
 
         $this->assertFalse($a->compare($b));
-        $this->assertTrue($a->compare($b, \ParserGenerator\SyntaxTreeNode\Base::COMPARE_DEFAULT xor \ParserGenerator\SyntaxTreeNode\Base::COMPARE_LEAF));
+        $this->assertTrue($a->compare($b,
+            \ParserGenerator\SyntaxTreeNode\Base::COMPARE_DEFAULT xor \ParserGenerator\SyntaxTreeNode\Base::COMPARE_LEAF));
     }
 
     protected function getTestNode1()

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -2,8 +2,8 @@
 
 use ParserGenerator\Parser;
 use ParserGenerator\SyntaxTreeNode\Branch;
-use ParserGenerator\SyntaxTreeNode\Root;
 use ParserGenerator\SyntaxTreeNode\Leaf;
+use ParserGenerator\SyntaxTreeNode\Root;
 
 class ParserTest extends PHPUnit_Framework_TestCase
 {
@@ -507,36 +507,48 @@ class ParserTest extends PHPUnit_Framework_TestCase
         $x = new Parser('start :=> "ab" "cd" .', array('ignoreWhitespaces' => true));
 
         $this->assertEquals("abcd", $x->parse("ab   cd")->toString());
-        $this->assertEquals("ab   cd", $x->parse("ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
-        $this->assertEquals("ab cd", $x->parse("ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
+        $this->assertEquals("ab   cd",
+            $x->parse("ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
+        $this->assertEquals("ab cd",
+            $x->parse("ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
 
         $this->assertEquals("abcd", $x->parse("ab \n cd ")->toString());
-        $this->assertEquals("ab \n cd ", $x->parse("ab \n cd ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
-        $this->assertEquals("ab\ncd", $x->parse("ab \n cd ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
+        $this->assertEquals("ab \n cd ",
+            $x->parse("ab \n cd ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
+        $this->assertEquals("ab\ncd",
+            $x->parse("ab \n cd ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
 
         $x = new Parser('start :=> /ab/ /cd/ .', array('ignoreWhitespaces' => true));
 
         $this->assertEquals("abcd", $x->parse("ab   cd")->toString());
-        $this->assertEquals("ab   cd", $x->parse("ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
-        $this->assertEquals("ab cd", $x->parse("ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
+        $this->assertEquals("ab   cd",
+            $x->parse("ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
+        $this->assertEquals("ab cd",
+            $x->parse("ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
 
         $this->assertEquals("abcd", $x->parse("ab \n cd ")->toString());
-        $this->assertEquals("ab \n cd ", $x->parse("ab \n cd ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
-        $this->assertEquals("ab\ncd", $x->parse("ab \n cd ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
+        $this->assertEquals("ab \n cd ",
+            $x->parse("ab \n cd ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
+        $this->assertEquals("ab\ncd",
+            $x->parse("ab \n cd ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
 
         $x = new Parser('start :=> /a/ /b/ .', array('ignoreWhitespaces' => true));
         $this->assertEquals("ab", $x->parse("a   b")->toString());
-        $this->assertEquals("a   \nb", $x->parse("a   \nb")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
+        $this->assertEquals("a   \nb",
+            $x->parse("a   \nb")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
 
         $x = new Parser('start :=> string .', array('ignoreWhitespaces' => true));
         $this->assertEquals("'abc'", $x->parse("'abc'  ")->toString());
-        $this->assertEquals("'abc'  ", $x->parse("'abc'  ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
+        $this->assertEquals("'abc'  ",
+            $x->parse("'abc'  ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
 
         $x = new Parser('start :=> /ab/ /cd/ .', array('ignoreWhitespaces' => true));
 
         $this->assertEquals("abcd", $x->parse(" ab   cd")->toString());
-        $this->assertEquals(" ab   cd", $x->parse(" ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
-        $this->assertEquals("ab cd", $x->parse(" ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
+        $this->assertEquals(" ab   cd",
+            $x->parse(" ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
+        $this->assertEquals("ab cd",
+            $x->parse(" ab   cd")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
     }
 
     public function testStringGrammarWhitespaceCharacters()
@@ -629,7 +641,8 @@ class ParserTest extends PHPUnit_Framework_TestCase
         $nodeDump = function ($parser) {
             $result = array();
             $parser->iterateOverNodes(function ($node) use (&$result) {
-                $explodedClassName = explode('\\', get_class(\ParserGenerator\GrammarNode\Decorator::undecorate($node)));
+                $explodedClassName = explode('\\',
+                    get_class(\ParserGenerator\GrammarNode\Decorator::undecorate($node)));
                 $className = $explodedClassName[count($explodedClassName) - 1];
                 $result[] = $className . '[' . $node . ']';
             });

--- a/tests/RegexUtilTest.php
+++ b/tests/RegexUtilTest.php
@@ -75,7 +75,8 @@ class RegexUtilTest extends PHPUnit_Framework_TestCase
         $this->assertCanStart(array('['), '/\\[/');
         $this->assertCanStart(array("\n", "\r", " ", "\t"), '/\\s/');
         $this->assertCanStart(array("\n", "\r", " ", "\t", "j"), '/[\\sj]/');
-        $this->assertEquals(255, count(\ParserGenerator\RegexUtil::getInstance()->getStartCharacters('/./'))); //256 - 1 cause \n is out
+        $this->assertEquals(255,
+            count(\ParserGenerator\RegexUtil::getInstance()->getStartCharacters('/./'))); //256 - 1 cause \n is out
     }
 
     protected function checkStringGenerate($regex, $results, $maxLength = 10)


### PR DESCRIPTION
So … 😄

No idea if you actually want to do this, but it didn't cost me much. I just used PhpStorm, made sure it's set to PSR1/PSR2, and hit reformat.

While reading the code I noticed many inconsistencies purely on the code base itself, most prominent mix of tabs and spaces (now: only spaces) and many other small things. I simply couldn't deduce a consistent style so I thought maybe you'd be interested in having it uniform, based on most prominent PHP coding standards (http://www.php-fig.org/psr/psr-1/ and http://www.php-fig.org/psr/psr-2/ ).

It may be overwhelming but I think it eases possible future contributions.

Thanks