### PR TITLE
Convert non-code tabs to space too

### DIFF
--- a/tests/Extension/ChoiceTest.php
+++ b/tests/Extension/ChoiceTest.php
@@ -12,7 +12,7 @@ class ChoiceTest extends PHPUnit_Framework_TestCase
     public function testBase()
     {
         $x = new Parser('start :=> (abc | "z" | /[qwe]/) "." .
-	                 abc   :=> "abc".');
+                         abc   :=> "abc".');
 
         $this->assertFalse($x->parse('ax.'));
         $this->assertFalse($x->parse('a.'));
@@ -26,7 +26,7 @@ class ChoiceTest extends PHPUnit_Framework_TestCase
     public function testChoiceSchouldNotCreateNewLevelInResult()
     {
         $x = new Parser('start :=> (abc | "z" | /[qwe]/) "." .
-	                 abc   :=> "abc".');
+                         abc   :=> "abc".');
 
         $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
             new \ParserGenerator\SyntaxTreeNode\Branch('abc', 0,
@@ -48,8 +48,8 @@ class ChoiceTest extends PHPUnit_Framework_TestCase
     public function testWithSeries()
     {
         $x = new Parser('start :=> (a | b)+ .
-	                 a     :=> "a".
-					 b     :=> "b".');
+                         a     :=> "a".
+                         b     :=> "b".');
 
         $this->assertFalse($x->parse(''));
         $this->assertFalse($x->parse('abc'));

--- a/tests/Extension/ItemRestrictions/ContainTest.php
+++ b/tests/Extension/ItemRestrictions/ContainTest.php
@@ -7,7 +7,7 @@ class ContainTest extends PHPUnit_Framework_TestCase
     public function test()
     {
         $x = new Parser("start :=> 'abcd'
-		                       :=> 'ab'.");
+                               :=> 'ab'.");
 
         $contain = new \ParserGenerator\Extension\ItemRestrictions\Contain($x->grammar['start']);
 
@@ -30,7 +30,7 @@ class ContainTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($contain->check('ab   ', 0, 5, null));
 
         $x = new Parser("start :=> 'abcd'
-		                       :=> 'ab'.", array('ignoreWhitespaces' => true));
+                               :=> 'ab'.", array('ignoreWhitespaces' => true));
 
         $contain = new \ParserGenerator\Extension\ItemRestrictions\Contain($x->grammar['start']);
 

--- a/tests/Extension/ItemRestrictions/IsTest.php
+++ b/tests/Extension/ItemRestrictions/IsTest.php
@@ -7,7 +7,7 @@ class IsTest extends PHPUnit_Framework_TestCase
     public function test()
     {
         $x = new Parser("start :=> 'abcd'
-		                       :=> 'ab'.");
+                               :=> 'ab'.");
 
         $contain = new \ParserGenerator\Extension\ItemRestrictions\Is($x->grammar['start']);
 
@@ -27,7 +27,7 @@ class IsTest extends PHPUnit_Framework_TestCase
         $x->cache = array();
 
         $x = new Parser("start :=> 'abcd'
-		                       :=> 'ab'.", array('ignoreWhitespaces' => true));
+                               :=> 'ab'.", array('ignoreWhitespaces' => true));
 
         $contain = new \ParserGenerator\Extension\ItemRestrictions\Is($x->grammar['start']);
 

--- a/tests/Extension/ItemRestrictionsTest.php
+++ b/tests/Extension/ItemRestrictionsTest.php
@@ -77,8 +77,8 @@ class ItemRestrictionsTest extends \PHPUnit_Framework_TestCase
     public function testWithNodes()
     {
         $x = new Parser('start           :=> text contain textInBranckets.
-		                 textInBranckets :=> "(" text ")"
-						                 :=> "[" text "]".');
+                         textInBranckets :=> "(" text ")"
+                                         :=> "[" text "]".');
 
         $this->assertFalse($x->parse('asdg'));
         $this->assertFalse($x->parse(''));
@@ -215,10 +215,10 @@ class ItemRestrictionsTest extends \PHPUnit_Framework_TestCase
          * without "not contain ..." string "<<<" would be parsed as well
          */
         $x = new Parser('start     :=> properText+tag.
-		                 tag       :=> open properText close.
-						 properText:=> text not contain ?(open|close).
-						 open      :=> "<<<".
-						 close     :=> ">>>".');
+                         tag       :=> open properText close.
+                         properText:=> text not contain ?(open|close).
+                         open      :=> "<<<".
+                         close     :=> ">>>".');
 
         $this->assertObject($x->parse("asd<<<asdfg>>>fsdf"));
         $this->assertObject($x->parse("as>d<<<as<<dfg>>>fsd><<f"));

--- a/tests/Extension/LookaheadTest.php
+++ b/tests/Extension/LookaheadTest.php
@@ -38,7 +38,7 @@ class LookaheadTest extends \PHPUnit_Framework_TestCase
     public function testSimplePositiveAfter()
     {
         $x = new Parser('start :=> x /.*/ .
-	                 x     :=> /.{3}/  !"a" .');
+                         x     :=> /.{3}/  !"a" .');
 
         $this->assertObject($x->parse('axcd'));
         $this->assertObject($x->parse('aaadaa'));
@@ -78,10 +78,10 @@ class LookaheadTest extends \PHPUnit_Framework_TestCase
         )), $x->parse("abc"));
 
         $x = new Parser('start :=> ?abc /.+/ .
-	                 abc   :=> a b c.
-					 a     :=> "a".
-					 b     :=> "b".
-					 c     :=> "c".');
+                         abc   :=> a b c.
+                         a     :=> "a".
+                         b     :=> "b".
+                         c     :=> "c".');
 
         $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
             new \ParserGenerator\SyntaxTreeNode\Leaf('abc')

--- a/tests/Extension/RuleConditionTest.php
+++ b/tests/Extension/RuleConditionTest.php
@@ -28,13 +28,13 @@ class RuleConditionTest extends \PHPUnit_Framework_TestCase
     public function testValidSubXML()
     {
         $x = new Parser('start    :=> xmlTag.
-	                 xmlText  :=> /[^<>]+/.
-					 xmlTag   :=> "<" /[a-z]+/ ">" xmlNodes "</" /[a-z]+/ ">" <? $s[1] == $s[5] ?>
-					          :=> "<" /[a-z]+/ "/>".
-					 xmlNodes :=> xmlNode xmlNodes
-					          :=> "".
-					 xmlNode  :=> xmlTag
-					          :=> xmlText.');
+                         xmlText  :=> /[^<>]+/.
+                         xmlTag   :=> "<" /[a-z]+/ ">" xmlNodes "</" /[a-z]+/ ">" <? $s[1] == $s[5] ?>
+                                  :=> "<" /[a-z]+/ "/>".
+                         xmlNodes :=> xmlNode xmlNodes
+                                  :=> "".
+                         xmlNode  :=> xmlTag
+                                  :=> xmlText.');
 
         $this->assertFalse($x->parse('<a><b>text</a>'));
         $this->assertFalse($x->parse('<a>text</b></a>'));
@@ -58,14 +58,14 @@ class RuleConditionTest extends \PHPUnit_Framework_TestCase
     public function testInvalidSubXML()
     {
         $x = new Parser('start    :=> xmlTag.
-	                 xmlText  :=> /[^<>]+/.
-					 xmlTag   :=> "<" /[a-z]+/ ">" xmlNodes "</" /[a-z]+/ ">" <? $s[1] == $s[5] ?>
-					          :=> "<" /[a-z]+/ "/>"
-							  :=> "<" /[a-z]+/ ">" xmlNodes.
-					 xmlNodes :=> xmlNode xmlNodes
-					          :=> "".
-					 xmlNode  :=> xmlTag
-					          :=> xmlText.');
+                         xmlText  :=> /[^<>]+/.
+                         xmlTag   :=> "<" /[a-z]+/ ">" xmlNodes "</" /[a-z]+/ ">" <? $s[1] == $s[5] ?>
+                                  :=> "<" /[a-z]+/ "/>"
+                                  :=> "<" /[a-z]+/ ">" xmlNodes.
+                         xmlNodes :=> xmlNode xmlNodes
+                                  :=> "".
+                         xmlNode  :=> xmlTag
+                                  :=> xmlText.');
 
         $this->assertObject($x->parse('<a><b>text</a>'));
         $this->assertFalse($x->parse('<a>text</b></a>'));
@@ -88,15 +88,15 @@ class RuleConditionTest extends \PHPUnit_Framework_TestCase
     public function testMadGrammar()
     {
         $x = new Parser('start      :=> content.
-	                 content  :=> spectext content 
-					          :=> /./ content
-							  :=> "".
-					 spectext :=> text3 content text3 <? (string) $s[0] == (string) $s[2] ?>
-							  :=> text2 content text2 <? (string) $s[0] == (string) $s[2] ?>
-							  :=> text1 content text1 <? (string) $s[0] == (string) $s[2] ?>.
-					 text1    :=> /./ .
-					 text2    :=> /.{2}/ .
-					 text3    :=> /.{3}/ .');
+                         content    :=> spectext content 
+                                    :=> /./ content
+                                    :=> "".
+                         spectext   :=> text3 content text3 <? (string) $s[0] == (string) $s[2] ?>
+                                    :=> text2 content text2 <? (string) $s[0] == (string) $s[2] ?>
+                                    :=> text1 content text1 <? (string) $s[0] == (string) $s[2] ?>.
+                         text1      :=> /./ .
+                         text2      :=> /.{2}/ .
+                         text3      :=> /.{3}/ .');
 
         $r = $x->parse('abab')->findAll('spectext');
         $this->assertEquals('abab', (string)$r[0]);

--- a/tests/Extension/SeriesTest.php
+++ b/tests/Extension/SeriesTest.php
@@ -14,9 +14,9 @@ class SeriesTest extends \PHPUnit_Framework_TestCase
     public function testPWithoutSeparator()
     {
         $x = new Parser('start :=> str+.
-	                 str   :=> "a"
-					       :=> "b"
-						   :=> "c".');
+                         str   :=> "a"
+                               :=> "b"
+                               :=> "c".');
 
 
         $this->assertFalse($x->parse('ax'));
@@ -44,9 +44,9 @@ class SeriesTest extends \PHPUnit_Framework_TestCase
     public function testMWithoutSeparator()
     {
         $x = new Parser('start :=> str*.
-	                 str   :=> "a"
-					       :=> "b"
-						   :=> "c".');
+                         str   :=> "a"
+                               :=> "b"
+                               :=> "c".');
 
 
         $this->assertFalse($x->parse('ax'));
@@ -62,10 +62,10 @@ class SeriesTest extends \PHPUnit_Framework_TestCase
     public function testWithSeparator()
     {
         $x = new Parser('start :=> str+coma.
-	                 coma  :=> ",".
-	                 str   :=> "a"
-					       :=> "b"
-						   :=> "c".');
+                         coma  :=> ",".
+                         str   :=> "a"
+                               :=> "b"
+                               :=> "c".');
 
         $this->assertFalse($x->parse('a,'));
         $this->assertObject($x->parse('a'));
@@ -158,7 +158,7 @@ class SeriesTest extends \PHPUnit_Framework_TestCase
     public function testSurrounded()
     {
         $x = new Parser('start :=> num+"," /b/.
-	                 num   :=> /\d+/.');
+                         num   :=> /\d+/.');
 
         $this->assertObject($x->parse('2,3b'));
     }


### PR DESCRIPTION
With #12 the inconsistency of spaces/tabs in the code were fixed, but
some of the in-line grammars still have tabs.

For consistency with the code itself (PSR => 4 spaces) I've converted
them to 4 spaces too and in some places where it was still off,
manually alligned them.

---
The Github diff is a good example why it makes sense, because GH renders tabs with 8 spaces.