### PR TITLE
Only use project-specific exceptions

### DIFF
--- a/src/Examples/ArithmeticExpressionParser.php
+++ b/src/Examples/ArithmeticExpressionParser.php
@@ -2,6 +2,8 @@
 
 namespace ParserGenerator\Examples;
 
+use ParserGenerator\Exception;
+
 class ArithmeticExpressionParser extends \ParserGenerator\Parser
 {
     public function __construct()
@@ -28,7 +30,7 @@ class ArithmeticExpressionParser extends \ParserGenerator\Parser
         if ($expr) {
             return $this->getExpressionValue($expr->getSubnode(0));
         } else {
-            throw new \Exception('Cannot parse arithmetic expression.');
+            throw new Exception('Cannot parse arithmetic expression.');
         }
     }
 

--- a/src/Examples/CSVParser.php
+++ b/src/Examples/CSVParser.php
@@ -9,6 +9,8 @@
 
 namespace ParserGenerator\Examples;
 
+use ParserGenerator\Exception;
+
 class CSVParser extends \ParserGenerator\Parser
 {
     public function __construct()
@@ -48,7 +50,7 @@ class CSVParser extends \ParserGenerator\Parser
 
             return $data;
         } else {
-            throw new \Exception('given string is not proper CSV format');
+            throw new Exception('given string is not proper CSV format');
         }
     }
 }

--- a/src/Examples/JSONFormater.php
+++ b/src/Examples/JSONFormater.php
@@ -2,6 +2,8 @@
 
 namespace ParserGenerator\Examples;
 
+use ParserGenerator\Exception;
+
 class JSONFormater extends \ParserGenerator\Parser
 {
     public function __construct()
@@ -40,7 +42,7 @@ class JSONFormater extends \ParserGenerator\Parser
 
             return $this->setIndention($node->getSubnode(0), $indention, $start);
         } elseif ($node->getType() !== 'value') {
-            throw new \Exception('Function JSONFormater::setIndention can be used only on nodes with type start or value');
+            throw new Exception('Function JSONFormater::setIndention can be used only on nodes with type start or value');
         }
 
         if ($node->getDetailType() == 'array' || $node->getDetailType() == 'object') {

--- a/src/Examples/JSONParser.php
+++ b/src/Examples/JSONParser.php
@@ -2,6 +2,8 @@
 
 namespace ParserGenerator\Examples;
 
+use ParserGenerator\Exception;
+
 class JSONParser extends \ParserGenerator\Parser
 {
     public function __construct()
@@ -27,7 +29,7 @@ class JSONParser extends \ParserGenerator\Parser
         $jsonTree = $this->parse($jsonString);
 
         if (!$jsonTree) {
-            throw new \Exception("Given string is not proper JSON");
+            throw new Exception("Given string is not proper JSON");
         }
 
         return $this->getValueOfNode($jsonTree->getSubnode(0));

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ParserGenerator;
+
+use RuntimeException;
+
+class Exception extends RuntimeException
+{
+}

--- a/src/Extension/Lookahead.php
+++ b/src/Extension/Lookahead.php
@@ -2,6 +2,8 @@
 
 namespace ParserGenerator\Extension;
 
+use ParserGenerator\Exception;
+
 class Lookahead extends \ParserGenerator\Extension\SequenceItem
 {
     protected function getGrammarGrammarSequence()
@@ -43,7 +45,7 @@ class Lookahead extends \ParserGenerator\Extension\SequenceItem
                 break;
 
             default:
-                throw new \Exception('that was unexpected');
+                throw new Exception('that was unexpected');
         }
 
         return new \ParserGenerator\GrammarNode\Lookahead($lookaheadNode, $mainNode, $before, $operator == '?');

--- a/src/GrammarNode/BranchFactory.php
+++ b/src/GrammarNode/BranchFactory.php
@@ -2,6 +2,8 @@
 
 namespace ParserGenerator\GrammarNode;
 
+use ParserGenerator\Exception;
+
 class BranchFactory
 {
     const NAIVE = 'naive';
@@ -18,7 +20,7 @@ class BranchFactory
             case self::PEG:
                 return new PEGBranch($name);
             default:
-                throw new \Exception("Unknown branch type: $branchType");
+                throw new Exception("Unknown branch type: $branchType");
         }
     }
 }

--- a/src/GrammarNode/Numeric.php
+++ b/src/GrammarNode/Numeric.php
@@ -3,6 +3,8 @@
 
 namespace ParserGenerator\GrammarNode;
 
+use ParserGenerator\Exception;
+
 class Numeric extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGenerator\GrammarNode\LeafInterface
 {
     protected $regexes;
@@ -35,11 +37,11 @@ class Numeric extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
         }
 
         if (!$this->formatDec && !$this->formatHex && !$this->formatOct && !$this->formatBin) {
-            throw new \Exception ('You must specify at least one proper format');
+            throw new Exception('You must specify at least one proper format');
         }
 
         if ($this->formatOct && $this->formatDec && ($this->requireFixedCharacters || $this->allowFixedCharacters)) {
-            throw new \Exception('options fixedCharacters and oct format canot be mixed together');
+            throw new Exception('options fixedCharacters and oct format canot be mixed together');
         }
 
         $this->buildRegexes();

--- a/src/GrammarNode/ParameterNode.php
+++ b/src/GrammarNode/ParameterNode.php
@@ -2,6 +2,8 @@
 
 namespace ParserGenerator\GrammarNode;
 
+use ParserGenerator\Exception;
+
 class ParameterNode extends BaseNode
 {
     protected $index;
@@ -17,7 +19,7 @@ class ParameterNode extends BaseNode
 
     public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
     {
-        throw new \Exception("this function should be never called on this node type");
+        throw new Exception("this function should be never called on this node type");
     }
 
     public function getIndex()
@@ -34,4 +36,4 @@ class ParameterNode extends BaseNode
     {
         return $this->parameterName;
     }
-} 
+}

--- a/src/GrammarNode/ParametrizedNode.php
+++ b/src/GrammarNode/ParametrizedNode.php
@@ -2,6 +2,7 @@
 
 namespace ParserGenerator\GrammarNode;
 
+use ParserGenerator\Exception;
 use ParserGenerator\GrammarNodeCopier;
 
 class ParametrizedNode extends BaseNode implements \ParserGenerator\ParserAwareInterface
@@ -37,7 +38,7 @@ class ParametrizedNode extends BaseNode implements \ParserGenerator\ParserAwareI
 
             if ($node instanceof ParameterNode) {
                 if (empty($params[$node->getIndex()])) {
-                    throw new \Exception("Parameter " . $node->getParameterName() . " with index " . $node->getIndex() . " in branch " . $node->getBranchName() . " not provided");
+                    throw new Exception("Parameter " . $node->getParameterName() . " with index " . $node->getIndex() . " in branch " . $node->getBranchName() . " not provided");
                 }
                 return $params[$node->getIndex()];
             }
@@ -78,4 +79,4 @@ class ParametrizedNode extends BaseNode implements \ParserGenerator\ParserAwareI
         $copy->setParser($this->getParser());
         return $copy;
     }
-} 
+}

--- a/src/GrammarNode/Regex.php
+++ b/src/GrammarNode/Regex.php
@@ -2,6 +2,8 @@
 
 namespace ParserGenerator\GrammarNode;
 
+use ParserGenerator\Exception;
+
 class Regex extends \ParserGenerator\GrammarNode\BaseNode Implements \ParserGenerator\GrammarNode\LeafInterface
 {
     public $lastMatch = -1;
@@ -25,7 +27,7 @@ class Regex extends \ParserGenerator\GrammarNode\BaseNode Implements \ParserGene
             }
             $this->regex = '/(' . $regexBody . ')?\s*/' . $regexModifiers;
         } else {
-            throw new \Exception ("Wrong regex format [$regex]");
+            throw new Exception("Wrong regex format [$regex]");
         }
     }
 

--- a/src/GrammarParser.php
+++ b/src/GrammarParser.php
@@ -88,7 +88,7 @@ class GrammarParser
             if (strlen($found) > $foundLength) {
                 $found = substr($found, 0, $foundLength) . '...';
             }
-            throw new \Exception("Given grammar is incorrect:\nline: " . $posData['line'] . ', character: ' . $posData['char'] . "\nexpected: " . $expected . "\nfound: " . $found);
+            throw new Exception("Given grammar is incorrect:\nline: " . $posData['line'] . ', character: ' . $posData['char'] . "\nexpected: " . $expected . "\nfound: " . $found);
         }
         $parsedGrammar->refreshOwners();
 
@@ -236,7 +236,7 @@ class GrammarParser
             if ($newSequence) {
                 return $newSequence;
             } else {
-                throw new \Exception('Rule type [' . $rule->getDetailType() . '] added but not supported');
+                throw new Exception('Rule type [' . $rule->getDetailType() . '] added but not supported');
             }
         }
     }
@@ -256,12 +256,12 @@ class GrammarParser
             if ($sequenceItem->getDetailType() === 'branch') {
                 $branchName = (string)$sequenceItem;
                 if (empty($grammar[$branchName])) {
-                    throw new \Exception("Grammar definition error: Undefined branch [$branchName]");
+                    throw new Exception("Grammar definition error: Undefined branch [$branchName]");
                 }
 
                 return $grammar[$branchName];
             } else {
-                throw new \Exception('Sequence item type [' . $sequenceItem->getDetailType() . '] added but not supported');
+                throw new Exception('Sequence item type [' . $sequenceItem->getDetailType() . '] added but not supported');
             }
         }
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -42,7 +42,7 @@ class Parser
                     } elseif ($seq instanceof \ParserGenerator\GrammarNode\NodeInterface) {
                         $grammarNodeOptions[$optionIndex][$seqIndex] = $seq;
                     } else {
-                        throw new \Exception('incorrect sequenceitem');
+                        throw new Exception('incorrect sequenceitem');
                     }
                 }
             }

--- a/src/RegexUtil.php
+++ b/src/RegexUtil.php
@@ -90,7 +90,7 @@ class RegexUtil
             $regex = $this->getParser()->parse($regex);
 
             if (empty($regex)) {
-                throw new \Exception('Invalid argument, [string isn\'t valid regular expression]');
+                throw new Exception('Invalid argument, [string isn\'t valid regular expression]');
             }
         }
 
@@ -102,7 +102,7 @@ class RegexUtil
             return $this->_canBeEmpty($regex);
         }
 
-        throw new \Exception('invalid argument given [epected string or \ParserGenerator\SyntaxTreeNode\Branch]');
+        throw new Exception('invalid argument given [epected string or \ParserGenerator\SyntaxTreeNode\Branch]');
     }
 
     protected function _canBeEmpty($node)
@@ -142,7 +142,7 @@ class RegexUtil
             $regex = $this->getParser()->parse($regex);
 
             if (empty($regex)) {
-                throw new \Exception('Invalid argument, [string isn\'t valid regular expression]');
+                throw new Exception('Invalid argument, [string isn\'t valid regular expression]');
             }
         }
 
@@ -154,7 +154,7 @@ class RegexUtil
             return $this->_getStartCharacters($regex);
         }
 
-        throw new \Exception('invalid argument given [epected string or \ParserGenerator\SyntaxTreeNode\Branch]');
+        throw new Exception('invalid argument given [epected string or \ParserGenerator\SyntaxTreeNode\Branch]');
     }
 
     protected function _getStartCharacters($node)
@@ -215,7 +215,7 @@ class RegexUtil
                             $result[substr((string)$node, 1, 1)] = true;
                             return $result;
                         default:
-                            throw new \Exception("Unknown character group [$node]");
+                            throw new Exception("Unknown character group [$node]");
                     }
                 } else {
                     $result = array();
@@ -269,7 +269,7 @@ class RegexUtil
             $regex = $this->getParser()->parse($regex);
 
             if (empty($regex)) {
-                throw new \Exception('Invalid argument, [string isn\'t valid regular expression]');
+                throw new Exception('Invalid argument, [string isn\'t valid regular expression]');
             }
         }
 
@@ -281,7 +281,7 @@ class RegexUtil
             return $this->_generateString($regex);
         }
 
-        throw new \Exception('invalid argument given [epected string or \ParserGenerator\SyntaxTreeNode\Branch]');
+        throw new Exception('invalid argument given [epected string or \ParserGenerator\SyntaxTreeNode\Branch]');
     }
 
     public function getOccurenceRange($node)
@@ -329,7 +329,7 @@ class RegexUtil
                     case 1:
                         return '';
                     case 2:
-                        throw new \Exception("canot generate regex string with lookaround");
+                        throw new Exception("canot generate regex string with lookaround");
                     case 3:
                         $occurenceRange = $this->getOccurenceRange($node->getSubnode(1));
                         if (empty($occurenceRange['max'])) {
@@ -361,7 +361,7 @@ class RegexUtil
                 }
 
             default:
-                throw new \Exception('this code should be never executed');
+                throw new Exception('this code should be never executed');
         }
     }
 }

--- a/src/SyntaxTreeNode/Branch.php
+++ b/src/SyntaxTreeNode/Branch.php
@@ -2,6 +2,8 @@
 
 namespace ParserGenerator\SyntaxTreeNode;
 
+use ParserGenerator\Exception;
+
 class Branch extends \ParserGenerator\SyntaxTreeNode\Base
 {
     protected $type;
@@ -202,7 +204,7 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
                             } elseif ($result instanceof \ParserGenerator\SyntaxTreeNode\Base) {
                                 $this->subnodes[$index] = $result;
                             } else {
-                                throw new \Exception('Result returned by callback in \ParserGenerator\SyntaxTreeNode\Branch::translate should be null|string|\ParserGenerator\SyntaxTreeNode\Base');
+                                throw new Exception('Result returned by callback in \ParserGenerator\SyntaxTreeNode\Branch::translate should be null|string|\ParserGenerator\SyntaxTreeNode\Base');
                             }
                         }
                     }


### PR DESCRIPTION
This makes integration into other software easier to respond to
exception only from this library.

Additionally the parent exception is deliberately *not* `\Exception`,
as this shouldn't be used for errors during run-time => thus the parent
is `\RuntimeException`.

---
This is basically a follow-up fix to #14