### PR TITLE
Make code PHP 7.2 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
 install: composer install
 script: phpunit --bootstrap="vendor/autoload.php" tests

--- a/src/GrammarNode/BranchStringCondition.php
+++ b/src/GrammarNode/BranchStringCondition.php
@@ -18,7 +18,7 @@ class BranchStringCondition extends \ParserGenerator\GrammarNode\BranchExtraCond
         $this->_functions = array();
 
         foreach ($conditionStrings as $detailType => $conditionString) {
-            $this->_functions[$detailType] = create_function('$string,$fromIndex,$toIndex,$node,$s',
+            $this->_functions[$detailType] = $this->create_function('$string,$fromIndex,$toIndex,$node,$s',
                 'return ' . $conditionString . ';');
         }
     }
@@ -33,5 +33,18 @@ class BranchStringCondition extends \ParserGenerator\GrammarNode\BranchExtraCond
         } else {
             return true;
         }
+    }
+
+    /**
+     * Emulate `create_function` (which was deprecated with PHP 7.2) tailored
+     * for the Grammar parser needs.
+     *
+     * @param string $arguments
+     * @param string $body
+     * @return \Closure
+     */
+    protected function create_function($arguments, $body)
+    {
+        return eval("return function ($arguments) { $body };");
     }
 }


### PR DESCRIPTION
`create_function` was deprecated in 7.2 and will thus fail phpunit.

This PR emulates the necessary parts using `eval()` by creating a
closure within eval and returning it.

The rest of the code works exactly the same.