### PR TITLE
Use array_fill as a more optimized version to fill an array with defaults

### DIFF
--- a/src/GrammarNode/Branch.php
+++ b/src/GrammarNode/Branch.php
@@ -40,9 +40,7 @@ class Branch extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGen
             $indexes = array(-1 => $fromIndex);
             $optionCount = count($option);
             //!!! TODO:
-            for ($i = 0; $i < $optionCount; $i++) {
-                $restrictedEnds[$i] = array();
-            }
+            $restrictedEnds = array_fill(0, $optionCount - 1, array());
             $restrictedEnds[$optionCount - 1] = $restrictedEnd;
             while (true) {
                 $subNode = $option[$optionIndex]->rparse($string, $indexes[$optionIndex - 1],


### PR DESCRIPTION
The `$optionCount - 1` can be improved by actually not including it
because the last one is always set from the parameter `$restrictedEnd`
anyway.

But that would require an additional `if`-check as to not get into a
negative second arg to `array_fill` and thus I didn't bother.