### PR TITLE
Enable strict types

### DIFF
--- a/src/Examples/ArithmeticExpressionParser.php
+++ b/src/Examples/ArithmeticExpressionParser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Examples;
 

--- a/src/Examples/CSVParser.php
+++ b/src/Examples/CSVParser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Created by JetBrains PhpStorm.
  * User: Rafał

--- a/src/Examples/JSONFormater.php
+++ b/src/Examples/JSONFormater.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Examples;
 

--- a/src/Examples/JSONParser.php
+++ b/src/Examples/JSONParser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Examples;
 

--- a/src/Examples/YamlLikeIndentationParser.php
+++ b/src/Examples/YamlLikeIndentationParser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Examples;
 

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator;
 

--- a/src/Extension/Base.php
+++ b/src/Extension/Base.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/Choice.php
+++ b/src/Extension/Choice.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/Integer.php
+++ b/src/Extension/Integer.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/ItemRestrictions.php
+++ b/src/Extension/ItemRestrictions.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/ItemRestrictions/Contain.php
+++ b/src/Extension/ItemRestrictions/Contain.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension\ItemRestrictions;
 

--- a/src/Extension/ItemRestrictions/FollowedBy.php
+++ b/src/Extension/ItemRestrictions/FollowedBy.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension\ItemRestrictions;
 

--- a/src/Extension/ItemRestrictions/Is.php
+++ b/src/Extension/ItemRestrictions/Is.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension\ItemRestrictions;
 

--- a/src/Extension/ItemRestrictions/ItemRestrictionAnd.php
+++ b/src/Extension/ItemRestrictions/ItemRestrictionAnd.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension\ItemRestrictions;
 

--- a/src/Extension/ItemRestrictions/ItemRestrictionInterface.php
+++ b/src/Extension/ItemRestrictions/ItemRestrictionInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension\ItemRestrictions;
 

--- a/src/Extension/ItemRestrictions/ItemRestrictionNot.php
+++ b/src/Extension/ItemRestrictions/ItemRestrictionNot.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension\ItemRestrictions;
 

--- a/src/Extension/ItemRestrictions/ItemRestrictionOr.php
+++ b/src/Extension/ItemRestrictions/ItemRestrictionOr.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension\ItemRestrictions;
 

--- a/src/Extension/Lookahead.php
+++ b/src/Extension/Lookahead.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/ParametrizedNode.php
+++ b/src/Extension/ParametrizedNode.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/Regex.php
+++ b/src/Extension/Regex.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/RuleCondition.php
+++ b/src/Extension/RuleCondition.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/SequenceItem.php
+++ b/src/Extension/SequenceItem.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/Series.php
+++ b/src/Extension/Series.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/StringObject.php
+++ b/src/Extension/StringObject.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/Text.php
+++ b/src/Extension/Text.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/TextNode.php
+++ b/src/Extension/TextNode.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/Time.php
+++ b/src/Extension/Time.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Created by PhpStorm.
  * User: Rafał

--- a/src/Extension/Unorder.php
+++ b/src/Extension/Unorder.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/Extension/WhiteCharactersContext.php
+++ b/src/Extension/WhiteCharactersContext.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\Extension;
 

--- a/src/GrammarNode/AnyText.php
+++ b/src/GrammarNode/AnyText.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/BaseNode.php
+++ b/src/GrammarNode/BaseNode.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/Branch.php
+++ b/src/GrammarNode/Branch.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/BranchDecorator.php
+++ b/src/GrammarNode/BranchDecorator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/BranchExtraCondition.php
+++ b/src/GrammarNode/BranchExtraCondition.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/BranchFactory.php
+++ b/src/GrammarNode/BranchFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/BranchInterface.php
+++ b/src/GrammarNode/BranchInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/BranchStringCondition.php
+++ b/src/GrammarNode/BranchStringCondition.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/Choice.php
+++ b/src/GrammarNode/Choice.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/Decorator.php
+++ b/src/GrammarNode/Decorator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/ErrorTrackDecorator.php
+++ b/src/GrammarNode/ErrorTrackDecorator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Created by PhpStorm.
  * User: Rafał

--- a/src/GrammarNode/ItemRestrictions.php
+++ b/src/GrammarNode/ItemRestrictions.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/LeafInterface.php
+++ b/src/GrammarNode/LeafInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/LeafTime.php
+++ b/src/GrammarNode/LeafTime.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/Lookahead.php
+++ b/src/GrammarNode/Lookahead.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/NaiveBranch.php
+++ b/src/GrammarNode/NaiveBranch.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/NodeInterface.php
+++ b/src/GrammarNode/NodeInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/Numeric.php
+++ b/src/GrammarNode/Numeric.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 //TODO: now this class supports only integers : add real support
 
 namespace ParserGenerator\GrammarNode;

--- a/src/GrammarNode/PEGBranch.php
+++ b/src/GrammarNode/PEGBranch.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/ParameterNode.php
+++ b/src/GrammarNode/ParameterNode.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/ParametrizedNode.php
+++ b/src/GrammarNode/ParametrizedNode.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/PredefinedSimpleString.php
+++ b/src/GrammarNode/PredefinedSimpleString.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/PredefinedString.php
+++ b/src/GrammarNode/PredefinedString.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/Regex.php
+++ b/src/GrammarNode/Regex.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/Series.php
+++ b/src/GrammarNode/Series.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/Text.php
+++ b/src/GrammarNode/Text.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/TextS.php
+++ b/src/GrammarNode/TextS.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/Unorder.php
+++ b/src/GrammarNode/Unorder.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/WhitespaceContextCheck.php
+++ b/src/GrammarNode/WhitespaceContextCheck.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNode/WhitespaceNegativeContextCheck.php
+++ b/src/GrammarNode/WhitespaceNegativeContextCheck.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\GrammarNode;
 

--- a/src/GrammarNodeCopier.php
+++ b/src/GrammarNodeCopier.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Created by PhpStorm.
  * User: Rafał

--- a/src/GrammarParser.php
+++ b/src/GrammarParser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator;
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator;
 

--- a/src/ParserAwareInterface.php
+++ b/src/ParserAwareInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator;
 

--- a/src/RegexUtil.php
+++ b/src/RegexUtil.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator;
 

--- a/src/SyntaxTreeNode/Base.php
+++ b/src/SyntaxTreeNode/Base.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\SyntaxTreeNode;
 

--- a/src/SyntaxTreeNode/Branch.php
+++ b/src/SyntaxTreeNode/Branch.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\SyntaxTreeNode;
 

--- a/src/SyntaxTreeNode/Leaf.php
+++ b/src/SyntaxTreeNode/Leaf.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\SyntaxTreeNode;
 

--- a/src/SyntaxTreeNode/LeafTime.php
+++ b/src/SyntaxTreeNode/LeafTime.php
@@ -24,7 +24,7 @@ class LeafTime extends Leaf
     {
         $result = new \DateTime();
         $result->setDate($this->timeData['year'], $this->timeData['month'], $this->timeData['day']);
-        $result->setTime($this->timeData['hour'], $this->timeData['minute'], $this->timeData['second']);
+        $result->setTime($this->timeData['hour'] ?: 0, $this->timeData['minute'] ?: 0, $this->timeData['second'] ?: 0);
 
         return $result;
     }

--- a/src/SyntaxTreeNode/LeafTime.php
+++ b/src/SyntaxTreeNode/LeafTime.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Created by PhpStorm.
  * User: Rafał

--- a/src/SyntaxTreeNode/Numeric.php
+++ b/src/SyntaxTreeNode/Numeric.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\SyntaxTreeNode;
 

--- a/src/SyntaxTreeNode/PredefinedString.php
+++ b/src/SyntaxTreeNode/PredefinedString.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\SyntaxTreeNode;
 

--- a/src/SyntaxTreeNode/Root.php
+++ b/src/SyntaxTreeNode/Root.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\SyntaxTreeNode;
 

--- a/src/SyntaxTreeNode/Series.php
+++ b/src/SyntaxTreeNode/Series.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ParserGenerator\SyntaxTreeNode;
 


### PR DESCRIPTION
- Only affects code _within_ the library, not the caller
- There are (almost?) no usages of type declarations, so no impact
  expected anyway
- However once type decl are implemented, they will be enforced and it
  it will be easier to spot possible problems earlier

One small fix was necessary: The hour/minute/second values can all contain `false`, thus the
shorthand ternary check.