### PR TITLE
Switch to short array syntax

### DIFF
--- a/src/Examples/ArithmeticExpressionParser.php
+++ b/src/Examples/ArithmeticExpressionParser.php
@@ -8,7 +8,7 @@ class ArithmeticExpressionParser extends \ParserGenerator\Parser
 {
     public function __construct()
     {
-        parent::__construct($this->getExpressionDefinition(), array('ignoreWhitespaces' => true));
+        parent::__construct($this->getExpressionDefinition(), ['ignoreWhitespaces' => true]);
     }
 
     public function getExpressionDefinition()

--- a/src/Examples/CSVParser.php
+++ b/src/Examples/CSVParser.php
@@ -34,9 +34,9 @@ class CSVParser extends \ParserGenerator\Parser
         $csvRaw = $this->parse($string);
 
         if ($csvRaw) {
-            $data = array();
+            $data = [];
             foreach ($csvRaw->getSubnode(0)->getMainNodes() as $csvLine) {
-                $line = array();
+                $line = [];
                 foreach ($csvLine->getSubnode(0)->getMainNodes() as $csvValue) {
                     if ($csvValue->getDetailType() == 0) {
                         $line[] = $csvValue->getSubnode(1)->getValue();

--- a/src/Examples/JSONFormater.php
+++ b/src/Examples/JSONFormater.php
@@ -9,7 +9,7 @@ class JSONFormater extends \ParserGenerator\Parser
     public function __construct()
     {
         parent::__construct($this->getJSONDefinition(),
-            array('ignoreWhitespaces' => true, 'defaultBranchType' => 'PEG'));
+            ['ignoreWhitespaces' => true, 'defaultBranchType' => 'PEG']);
     }
 
     protected function getJSONDefinition()

--- a/src/Examples/JSONParser.php
+++ b/src/Examples/JSONParser.php
@@ -8,7 +8,7 @@ class JSONParser extends \ParserGenerator\Parser
 {
     public function __construct()
     {
-        parent::__construct($this->getJSONDefinition(), array('ignoreWhitespaces' => true));
+        parent::__construct($this->getJSONDefinition(), ['ignoreWhitespaces' => true]);
     }
 
     protected function getJSONDefinition()
@@ -44,7 +44,7 @@ class JSONParser extends \ParserGenerator\Parser
             case "number":
                 return $node->getSubnode(0)->getValue();
             case "array":
-                $result = array();
+                $result = [];
 
                 foreach ($node->getSubnode(1)->getMainNodes() as $valueNode) {
                     $result[] = $this->getValueOfNode($valueNode);
@@ -52,7 +52,7 @@ class JSONParser extends \ParserGenerator\Parser
 
                 return $result;
             case "object":
-                $result = array();
+                $result = [];
 
                 foreach ($node->getSubnode(1)->getMainNodes() as $objValueNode) {
                     $result[$objValueNode->getSubnode(0)->getValue()] = $this->getValueOfNode($objValueNode->getSubnode(2));

--- a/src/Examples/YamlLikeIndentationParser.php
+++ b/src/Examples/YamlLikeIndentationParser.php
@@ -46,7 +46,7 @@ class YamlLikeIndentationParser extends \ParserGenerator\Parser
         } elseif ($node->getType() == 'value' && $node->getDetailType() == 'object') {
             return $this->getValueOfNode($node->getSubnode(0));
         } elseif ($node->getType() == 'objValues' && $node->getDetailType() == 'values') {
-            $result = array();
+            $result = [];
             foreach ($node->getSubnode(0)->getMainNodes() as $objValue) {
                 $result[(string)$objValue->getSubnode(2)] = $this->getValueOfNode($objValue->getSubnode(5));
             }

--- a/src/Extension/Choice.php
+++ b/src/Extension/Choice.php
@@ -8,22 +8,22 @@ class Choice extends \ParserGenerator\Extension\SequenceItem
 
     public function extendGrammar($grammarGrammar)
     {
-        $grammarGrammar[$this->seqName] = array(
-            'nest' => array(':sequence', '|', (':' . $this->seqName)),
-            'last' => array(':sequence')
-        );
+        $grammarGrammar[$this->seqName] = [
+            'nest' => [':sequence', '|', (':' . $this->seqName)],
+            'last' => [':sequence'],
+        ];
 
         return parent::extendGrammar($grammarGrammar);
     }
 
     protected function getGrammarGrammarSequence()
     {
-        return array('(', (':' . $this->seqName), ':comments', ')');
+        return ['(', (':' . $this->seqName), ':comments', ')'];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
-        $choices = array();
+        $choices = [];
         $sequenceNode = $sequenceItem->getSubnode(1);
 
         while ($sequenceNode->getDetailType() !== 'last') {
@@ -44,7 +44,7 @@ class Choice extends \ParserGenerator\Extension\SequenceItem
 
     private function buildInternalSequence(&$grammar, $sequence, $grammarParser, $options)
     {
-        $choice = array();
+        $choice = [];
 
         foreach ($sequence->findAll('sequenceItem') as $sequenceItem) {
             $choice[] = $grammarParser->buildSequenceItem($grammar, $sequenceItem, $options);

--- a/src/Extension/Integer.php
+++ b/src/Extension/Integer.php
@@ -8,56 +8,56 @@ class Integer extends \ParserGenerator\Extension\SequenceItem
 
     public function extendGrammar($grammarGrammar)
     {
-        $grammarGrammar[$this->getNS(null, false)] = array(
-            array(
+        $grammarGrammar[$this->getNS(null, false)] = [
+            [
                 $this->getNS('LowBound'),
                 new \ParserGenerator\GrammarNode\Text('..'),
                 $this->getNS('HiBound'),
                 $this->getNs('modifiers'),
-                ''
-            )
-        );
+                '',
+            ],
+        ];
 
-        $grammarGrammar[$this->getNS('LowBound', false)] = array(
-            array(new \ParserGenerator\GrammarNode\Text('-inf')),
-            array(new \ParserGenerator\GrammarNode\Text('-infinity')),
-            'int' => array(
-                new \ParserGenerator\GrammarNode\Numeric(array(
+        $grammarGrammar[$this->getNS('LowBound', false)] = [
+            [new \ParserGenerator\GrammarNode\Text('-inf')],
+            [new \ParserGenerator\GrammarNode\Text('-infinity')],
+            'int' => [
+                new \ParserGenerator\GrammarNode\Numeric([
                     'formatHex' => true,
                     'formatBin' => true,
-                    'allowFixedCharacters' => true
-                ))
-            )
-        );
-        $grammarGrammar[$this->getNS('HiBound', false)] = array(
-            array(new \ParserGenerator\GrammarNode\Text('inf')),
-            array(new \ParserGenerator\GrammarNode\Text('infinity')),
-            'int' => array(
-                new \ParserGenerator\GrammarNode\Numeric(array(
+                    'allowFixedCharacters' => true,
+                ]),
+            ],
+        ];
+        $grammarGrammar[$this->getNS('HiBound', false)] = [
+            [new \ParserGenerator\GrammarNode\Text('inf')],
+            [new \ParserGenerator\GrammarNode\Text('infinity')],
+            'int' => [
+                new \ParserGenerator\GrammarNode\Numeric([
                     'formatHex' => true,
                     'formatBin' => true,
-                    'allowFixedCharacters' => true
-                ))
-            )
-        );
+                    'allowFixedCharacters' => true,
+                ]),
+            ],
+        ];
 
-        $grammarGrammar[$this->getNS('modifiers', false)] = array(
-            array(new \ParserGenerator\GrammarNode\Text('/'), $this->getNS('modifierList')),
-            array('')
-        );
+        $grammarGrammar[$this->getNS('modifiers', false)] = [
+            [new \ParserGenerator\GrammarNode\Text('/'), $this->getNS('modifierList')],
+            [''],
+        ];
 
-        $grammarGrammar[$this->getNS('modifierList', false)] = array(
-            array($this->getNS('modifier'), $this->getNS('modifierList')),
-            array($this->getNS('modifier'))
-        );
+        $grammarGrammar[$this->getNS('modifierList', false)] = [
+            [$this->getNS('modifier'), $this->getNS('modifierList')],
+            [$this->getNS('modifier')],
+        ];
 
-        $grammarGrammar[$this->getNS('modifier', false)] = array(
-            'formatHex' => array(new \ParserGenerator\GrammarNode\Text('h')),
-            'formatDec' => array(new \ParserGenerator\GrammarNode\Text('d')),
-            'formatOct' => array(new \ParserGenerator\GrammarNode\Text('o')),
-            'formatBin' => array(new \ParserGenerator\GrammarNode\Text('b')),
-            'fixed' => array(new \ParserGenerator\GrammarNode\Regex('/\d+/'))
-        );
+        $grammarGrammar[$this->getNS('modifier', false)] = [
+            'formatHex' => [new \ParserGenerator\GrammarNode\Text('h')],
+            'formatDec' => [new \ParserGenerator\GrammarNode\Text('d')],
+            'formatOct' => [new \ParserGenerator\GrammarNode\Text('o')],
+            'formatBin' => [new \ParserGenerator\GrammarNode\Text('b')],
+            'fixed' => [new \ParserGenerator\GrammarNode\Regex('/\d+/')],
+        ];
 
         return parent::extendGrammar($grammarGrammar);
     }
@@ -69,12 +69,12 @@ class Integer extends \ParserGenerator\Extension\SequenceItem
 
     protected function getGrammarGrammarSequence()
     {
-        return array($this->getNS(''));
+        return [$this->getNS('')];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
-        $numericOptions = array();
+        $numericOptions = [];
         $numericOptions['eatWhiteChars'] = !empty($options['ignoreWhitespaces']);
 
         $item = $sequenceItem->getSubnode(0);
@@ -123,7 +123,7 @@ class Integer extends \ParserGenerator\Extension\SequenceItem
         }
 
         foreach ($modifiers as $modifier) {
-            if (in_array($modifier->getDetailType(), array('formatDec', 'formatHex', 'formatOct', 'formatBin'))) {
+            if (in_array($modifier->getDetailType(), ['formatDec', 'formatHex', 'formatOct', 'formatBin'])) {
                 $numericOptions[$modifier->getDetailType()] = true;
             } elseif ($modifier->getDetailType() === 'fixed') {
                 if ((string)$modifier === '0') {

--- a/src/Extension/ItemRestrictions.php
+++ b/src/Extension/ItemRestrictions.php
@@ -20,29 +20,29 @@ class ItemRestrictions extends \ParserGenerator\Extension\SequenceItem
 
     public function extendGrammar($grammarGrammar)
     {
-        $grammarGrammar[$this->getNS('', false)] = array(
-            array(
+        $grammarGrammar[$this->getNS('', false)] = [
+            [
                 ':sequenceItem',
-                $this->getNS('condition')
-            )
-        );
+                $this->getNS('condition'),
+            ],
+        ];
 
-        $grammarGrammar[$this->getNS('condition', false)] = array(
-            array($this->getNS('conditionAnd'), 'or', $this->getNS('condition')),
-            'last' => array($this->getNS('conditionAnd'))
-        );
+        $grammarGrammar[$this->getNS('condition', false)] = [
+            [$this->getNS('conditionAnd'), 'or', $this->getNS('condition')],
+            'last' => [$this->getNS('conditionAnd')],
+        ];
 
-        $grammarGrammar[$this->getNS('conditionAnd', false)] = array(
-            array($this->getNS('simpleCondition'), 'and', $this->getNS('conditionAnd')),
-            'last' => array($this->getNS('simpleCondition'))
-        );
+        $grammarGrammar[$this->getNS('conditionAnd', false)] = [
+            [$this->getNS('simpleCondition'), 'and', $this->getNS('conditionAnd')],
+            'last' => [$this->getNS('simpleCondition')],
+        ];
 
-        $grammarGrammar[$this->getNS('simpleCondition', false)] = array(
-            'bracket' => array('(', $this->getNS('condition'), ':comments', ')'),
-            'not' => array('not', $this->getNS('simpleCondition')),
-            'contain' => array('contain', ':sequenceItem'),
-            'is' => array('is', ':sequenceItem')
-        );
+        $grammarGrammar[$this->getNS('simpleCondition', false)] = [
+            'bracket' => ['(', $this->getNS('condition'), ':comments', ')'],
+            'not' => ['not', $this->getNS('simpleCondition')],
+            'contain' => ['contain', ':sequenceItem'],
+            'is' => ['is', ':sequenceItem'],
+        ];
 
         return parent::extendGrammar($grammarGrammar);
     }
@@ -54,7 +54,7 @@ class ItemRestrictions extends \ParserGenerator\Extension\SequenceItem
 
     protected function getGrammarGrammarSequence()
     {
-        return array($this->getNS(''));
+        return [$this->getNS('')];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
@@ -77,20 +77,20 @@ class ItemRestrictions extends \ParserGenerator\Extension\SequenceItem
                 if ($node->getDetailType() === 'last') {
                     return $this->buildCondition($node->getSubnode(0));
                 } else {
-                    return new ItemRestrictionOr(array(
+                    return new ItemRestrictionOr([
                         $this->buildCondition($node->getSubnode(0)),
-                        $this->buildCondition($node->getSubnode(2))
-                    ));
+                        $this->buildCondition($node->getSubnode(2)),
+                    ]);
                 }
 
             case $this->getNS('conditionAnd', false):
                 if ($node->getDetailType() === 'last') {
                     return $this->buildCondition($node->getSubnode(0));
                 } else {
-                    return new ItemRestrictionAnd(array(
+                    return new ItemRestrictionAnd([
                         $this->buildCondition($node->getSubnode(0)),
-                        $this->buildCondition($node->getSubnode(2))
-                    ));
+                        $this->buildCondition($node->getSubnode(2)),
+                    ]);
                 }
 
             case $this->getNS('simpleCondition', false):

--- a/src/Extension/ItemRestrictions/Contain.php
+++ b/src/Extension/ItemRestrictions/Contain.php
@@ -14,7 +14,7 @@ class Contain implements \ParserGenerator\Extension\ItemRestrictions\ItemRestric
     public function check($string, $fromIndex, $toIndex, $node)
     {
         for ($currentIndex = $fromIndex; $currentIndex < $toIndex; $currentIndex++) {
-            $restrictedEnds = array();
+            $restrictedEnds = [];
             while (true) {
                 $parsedNode = $this->grammarNode->rparse($string, $currentIndex, $restrictedEnds);
 

--- a/src/Extension/ItemRestrictions/FollowedBy.php
+++ b/src/Extension/ItemRestrictions/FollowedBy.php
@@ -13,6 +13,6 @@ class FollowedBy implements \ParserGenerator\Extension\ItemRestrictions\ItemRest
 
     public function check($string, $fromIndex, $toIndex, $node)
     {
-        return (bool)$this->grammarNode->rparse($string, $toIndex, array());
+        return (bool)$this->grammarNode->rparse($string, $toIndex, []);
     }
 }

--- a/src/Extension/ItemRestrictions/Is.php
+++ b/src/Extension/ItemRestrictions/Is.php
@@ -13,7 +13,7 @@ class Is implements \ParserGenerator\Extension\ItemRestrictions\ItemRestrictionI
 
     public function check($string, $fromIndex, $toIndex, $node)
     {
-        $restrictedEnds = array();
+        $restrictedEnds = [];
         while (true) {
             $parsedNode = $this->grammarNode->rparse($string, $fromIndex, $restrictedEnds);
 

--- a/src/Extension/Lookahead.php
+++ b/src/Extension/Lookahead.php
@@ -12,11 +12,11 @@ class Lookahead extends \ParserGenerator\Extension\SequenceItem
         $whiteChar = new \ParserGenerator\GrammarNode\WhitespaceContextCheck(null);
         $operator = ':/[!?]/';
 
-        return array(
-            array($operator, $noWhiteChar, ':sequenceItem', $whiteChar, ':sequenceItem'),
-            array(':sequenceItem', $whiteChar, $operator, $noWhiteChar, ':sequenceItem'),
-            array($operator, $noWhiteChar, ':sequenceItem'),
-        );
+        return [
+            [$operator, $noWhiteChar, ':sequenceItem', $whiteChar, ':sequenceItem'],
+            [':sequenceItem', $whiteChar, $operator, $noWhiteChar, ':sequenceItem'],
+            [$operator, $noWhiteChar, ':sequenceItem'],
+        ];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)

--- a/src/Extension/ParametrizedNode.php
+++ b/src/Extension/ParametrizedNode.php
@@ -12,31 +12,31 @@ class ParametrizedNode extends Base
 
     public function extendGrammar($grammarGrammar)
     {
-        $this->nodeParams = array();
+        $this->nodeParams = [];
 
         $grammarGrammar['grammarBranch']['standard'] = $this->insert($grammarGrammar['grammarBranch']['standard'],
             ':branchName', ':branchParamsDef');
 
-        $grammarGrammar['branchParamsDef'] = array(
-            array('<', ':branchParamsDefList', '>'),
-            array('')
-        );
+        $grammarGrammar['branchParamsDef'] = [
+            ['<', ':branchParamsDefList', '>'],
+            [''],
+        ];
 
-        $grammarGrammar['branchParamsDefList'] = array(
-            'last' => array(':branchName'),
-            'notLast' => array(':branchName', ',', ':branchParamsDefList')
-        );
+        $grammarGrammar['branchParamsDefList'] = [
+            'last' => [':branchName'],
+            'notLast' => [':branchName', ',', ':branchParamsDefList'],
+        ];
 
-        $grammarGrammar['sequenceItem']['parametrizedNode'] = array(
+        $grammarGrammar['sequenceItem']['parametrizedNode'] = [
             ':branchName',
             '<',
             ':parametrizedNodeParamsList',
-            '>'
-        );
-        $grammarGrammar['parametrizedNodeParamsList'] = array(
-            'last' => array(':sequenceItem'),
-            'notLast' => array(':sequenceItem', ',', ':parametrizedNodeParamsList')
-        );
+            '>',
+        ];
+        $grammarGrammar['parametrizedNodeParamsList'] = [
+            'last' => [':sequenceItem'],
+            'notLast' => [':sequenceItem', ',', ':parametrizedNodeParamsList'],
+        ];
 
         return $grammarGrammar;
     }
@@ -66,7 +66,7 @@ class ParametrizedNode extends Base
         }
 
         if ($sequenceItem->getDetailType() === 'parametrizedNode') {
-            $params = array();
+            $params = [];
             foreach ($sequenceItem->findFirst('parametrizedNodeParamsList')->findAll('sequenceItem') as $param) {
                 $params[] = $grammarParser->buildSequenceItem($grammar, $param, $options);
             }

--- a/src/Extension/Regex.php
+++ b/src/Extension/Regex.php
@@ -6,7 +6,7 @@ class Regex extends \ParserGenerator\Extension\SequenceItem
 {
     protected function getGrammarGrammarSequence()
     {
-        return array(':/\\/([^*\\\\\\/]|\\\\.)([^\\\\\\/]|\\\\.)*\\/[a-zA-Z]*/');
+        return [':/\\/([^*\\\\\\/]|\\\\.)([^\\\\\\/]|\\\\.)*\\/[a-zA-Z]*/'];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)

--- a/src/Extension/RuleCondition.php
+++ b/src/Extension/RuleCondition.php
@@ -7,8 +7,8 @@ class RuleCondition extends \ParserGenerator\Extension\Base
     public function extendGrammar($grammarGrammar)
     {
         $grammarGrammar['rule']['standard'][] = ':possibleRuleCondition';
-        $grammarGrammar['possibleRuleCondition'] = array(array(':ruleCondition'), array(''));
-        $grammarGrammar['ruleCondition']['standard'] = array('<?', ':/([^?]|\?[^>])+/', '?>');
+        $grammarGrammar['possibleRuleCondition'] = [[':ruleCondition'], ['']];
+        $grammarGrammar['ruleCondition']['standard'] = ['<?', ':/([^?]|\?[^>])+/', '?>'];
 
         return $grammarGrammar;
     }
@@ -16,7 +16,7 @@ class RuleCondition extends \ParserGenerator\Extension\Base
     function modifyBranches($grammar, $parsedGrammar, $grammarParser, $options)
     {
         foreach ($parsedGrammar->findAll('grammarBranch') as $grammarBranch) {
-            $functions = array();
+            $functions = [];
             foreach ($grammarBranch->findAll('rule') as $ruleIndex => $rule) {
                 $ruleName = (string)$rule->findFirst('ruleName') ?: $ruleIndex;
                 if ($condition = $rule->findFirst('ruleCondition')) {

--- a/src/Extension/Series.php
+++ b/src/Extension/Series.php
@@ -11,10 +11,10 @@ class Series extends \ParserGenerator\Extension\SequenceItem
         $operator = ':/(\*{1,2}|\+{1,2}|\?{1,2})/';
         $noWhiteChar = new \ParserGenerator\GrammarNode\WhitespaceNegativeContextCheck(null);
 
-        return array(
-            array(':sequenceItem', $noWhiteChar, $operator, $noWhiteChar, ':sequenceItem'),
-            array(':sequenceItem', $noWhiteChar, $operator)
-        );
+        return [
+            [':sequenceItem', $noWhiteChar, $operator, $noWhiteChar, ':sequenceItem'],
+            [':sequenceItem', $noWhiteChar, $operator],
+        ];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
@@ -35,9 +35,9 @@ class Series extends \ParserGenerator\Extension\SequenceItem
             case '**':
             case '+':
             case '*':
-                $greedy = in_array($operator, array('**', '++')) || $forceGreedy;
+                $greedy = in_array($operator, ['**', '++']) || $forceGreedy;
                 $node = new \ParserGenerator\GrammarNode\Series($main, $separator,
-                    in_array($operator, array('*', '**')), $greedy);
+                    in_array($operator, ['*', '**']), $greedy);
                 if (isset($options['parser'])) {
                     $node->setParser($options['parser']);
                 }
@@ -46,7 +46,7 @@ class Series extends \ParserGenerator\Extension\SequenceItem
             case '??':
             case '?':
                 $empty = new \ParserGenerator\GrammarNode\Text('');
-                $choices = ($operator == '??' || $forceGreedy) ? array($main, $empty) : array($empty, $main);
+                $choices = ($operator == '??' || $forceGreedy) ? [$main, $empty] : [$empty, $main];
                 $node = new \ParserGenerator\GrammarNode\Choice($choices);
 
                 if (isset($options['parser'])) {

--- a/src/Extension/StringObject.php
+++ b/src/Extension/StringObject.php
@@ -6,10 +6,10 @@ class StringObject extends \ParserGenerator\Extension\SequenceItem
 {
     protected function getGrammarGrammarSequence()
     {
-        return array(
-            array('string'),
-            array('string/', ':/(apostrophe|simple|quotation|default)/')
-        );
+        return [
+            ['string'],
+            ['string/', ':/(apostrophe|simple|quotation|default)/'],
+        ];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
@@ -19,15 +19,15 @@ class StringObject extends \ParserGenerator\Extension\SequenceItem
         switch ($type) {
             case "default":
                 return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']),
-                    array("'", '"'));
+                    ["'", '"']);
 
             case "apostrophe":
                 return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']),
-                    array("'"));
+                    ["'"]);
 
             case "quotation":
                 return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']),
-                    array('"'));
+                    ['"']);
 
             case "simple":
                 return new \ParserGenerator\GrammarNode\PredefinedSimpleString(!empty($options['ignoreWhitespaces']));

--- a/src/Extension/Text.php
+++ b/src/Extension/Text.php
@@ -8,11 +8,11 @@ class Text extends \ParserGenerator\Extension\SequenceItem
 
     public function extendGrammar($grammarGrammar)
     {
-        $grammarGrammar[$this->getNS(null, false)] = array(
-            array(
+        $grammarGrammar[$this->getNS(null, false)] = [
+            [
                 'text',
-            )
-        );
+            ],
+        ];
 
         return parent::extendGrammar($grammarGrammar);
     }
@@ -24,7 +24,7 @@ class Text extends \ParserGenerator\Extension\SequenceItem
 
     protected function getGrammarGrammarSequence()
     {
-        return array($this->getNS(''));
+        return [$this->getNS('')];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)

--- a/src/Extension/TextNode.php
+++ b/src/Extension/TextNode.php
@@ -6,7 +6,7 @@ class TextNode extends \ParserGenerator\Extension\SequenceItem
 {
     protected function getGrammarGrammarSequence()
     {
-        return array(':string');
+        return [':string'];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)

--- a/src/Extension/Time.php
+++ b/src/Extension/Time.php
@@ -14,9 +14,9 @@ class Time extends \ParserGenerator\Extension\SequenceItem
 {
     protected function getGrammarGrammarSequence()
     {
-        return array(
-            array('time(', ':/[^)]+/', ')')
-        );
+        return [
+            ['time(', ':/[^)]+/', ')'],
+        ];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)

--- a/src/Extension/Unorder.php
+++ b/src/Extension/Unorder.php
@@ -8,17 +8,17 @@ class Unorder extends \ParserGenerator\Extension\SequenceItem
 
     public function extendGrammar($grammarGrammar)
     {
-        $grammarGrammar[$this->seqName] = array(
-            'nest' => array(':/[?*+]?/', ':sequenceItem', ',', (':' . $this->seqName)),
-            'last' => array(':/[?*+]?/', ':sequenceItem')
-        );
+        $grammarGrammar[$this->seqName] = [
+            'nest' => [':/[?*+]?/', ':sequenceItem', ',', (':' . $this->seqName)],
+            'last' => [':/[?*+]?/', ':sequenceItem'],
+        ];
 
         return parent::extendGrammar($grammarGrammar);
     }
 
     protected function getGrammarGrammarSequence()
     {
-        return array(array('unorder(', ':sequenceItem', ',', (':' . $this->seqName), ')'));
+        return [['unorder(', ':sequenceItem', ',', (':' . $this->seqName), ')']];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
@@ -45,7 +45,7 @@ class Unorder extends \ParserGenerator\Extension\SequenceItem
 
     private function buildInternalSequence(&$grammar, $sequence, $grammarParser, $options)
     {
-        $choice = array();
+        $choice = [];
 
         foreach ($sequence->findAll('sequenceItem') as $sequenceItem) {
             $choice[] = $grammarParser->buildSequenceItem($grammar, $sequenceItem, $options);

--- a/src/Extension/WhiteCharactersContext.php
+++ b/src/Extension/WhiteCharactersContext.php
@@ -6,7 +6,7 @@ class WhiteCharactersContext extends \ParserGenerator\Extension\SequenceItem
 {
     protected function getGrammarGrammarSequence()
     {
-        return array(':/(\\\\s|whiteSpace|\\\\space|space|\\\\n|newLine|\\\\newline|\\\\t|\\\\tab|tab)/');
+        return [':/(\\\\s|whiteSpace|\\\\space|space|\\\\n|newLine|\\\\newline|\\\\t|\\\\tab|tab)/'];
     }
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)

--- a/src/GrammarNode/AnyText.php
+++ b/src/GrammarNode/AnyText.php
@@ -4,15 +4,15 @@ namespace ParserGenerator\GrammarNode;
 
 class AnyText extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGenerator\GrammarNode\LeafInterface
 {
-    public static $whiteChars = array("\n" => true, "\t" => true, "\r" => true, " " => true);
+    public static $whiteChars = ["\n" => true, "\t" => true, "\r" => true, " " => true];
     public $ignoreWhitespaces;
 
-    public function __construct($options = array())
+    public function __construct($options = [])
     {
         $this->ignoreWhitespaces = true;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         $endPos = $this->getNextNonrestrictedIndex($string, $fromIndex, $restrictedEnd);
         $str = substr($string, $fromIndex, $endPos - $fromIndex);
@@ -21,12 +21,12 @@ class AnyText extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
             if ($this->ignoreWhitespaces) {
                 $trimedString = rtrim($str);
                 $whitespaces = substr($str, strlen($trimedString));
-                return array(
+                return [
                     'node' => new \ParserGenerator\SyntaxTreeNode\Leaf($trimedString, $whitespaces),
-                    'offset' => $endPos
-                );
+                    'offset' => $endPos,
+                ];
             } else {
-                return array('node' => new \ParserGenerator\SyntaxTreeNode\Leaf($str), 'offset' => $endPos);
+                return ['node' => new \ParserGenerator\SyntaxTreeNode\Leaf($str), 'offset' => $endPos];
             }
         } else {
             return false;

--- a/src/GrammarNode/BaseNode.php
+++ b/src/GrammarNode/BaseNode.php
@@ -4,5 +4,5 @@ namespace ParserGenerator\GrammarNode;
 
 abstract class BaseNode implements \ParserGenerator\GrammarNode\NodeInterface
 {
-    abstract public function rparse($string, $fromIndex = 0, $restrictedEnd = array());
+    abstract public function rparse($string, $fromIndex = 0, $restrictedEnd = []);
 }

--- a/src/GrammarNode/Branch.php
+++ b/src/GrammarNode/Branch.php
@@ -19,7 +19,7 @@ class Branch extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGen
         $this->nodeShortName = $nodeName;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         $cacheStr = $fromIndex . '-' . $this->nodeName . '-' . implode(',', $restrictedEnd);
         $lastResult = 31;
@@ -35,12 +35,12 @@ class Branch extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGen
         }
         beforeForeach:
         foreach ($this->node as $_optionIndex => $option) {
-            $subnodes = array();
+            $subnodes = [];
             $optionIndex = 0;
-            $indexes = array(-1 => $fromIndex);
+            $indexes = [-1 => $fromIndex];
             $optionCount = count($option);
             //!!! TODO:
-            $restrictedEnds = array_fill(0, $optionCount - 1, array());
+            $restrictedEnds = array_fill(0, $optionCount - 1, []);
             $restrictedEnds[$optionCount - 1] = $restrictedEnd;
             while (true) {
                 $subNode = $option[$optionIndex]->rparse($string, $indexes[$optionIndex - 1],
@@ -60,7 +60,7 @@ class Branch extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGen
             // match
             $index = $indexes[$optionCount - 1];
             $node = new \ParserGenerator\SyntaxTreeNode\Branch($this->nodeShortName, $_optionIndex, $subnodes);
-            $r = array('node' => $node, 'offset' => $index);
+            $r = ['node' => $node, 'offset' => $index];
             $this->parser->cache[$cacheStr] = $r;
             if ($r != $lastResult) {
                 $lastResult = $r;

--- a/src/GrammarNode/BranchStringCondition.php
+++ b/src/GrammarNode/BranchStringCondition.php
@@ -15,7 +15,7 @@ class BranchStringCondition extends \ParserGenerator\GrammarNode\BranchExtraCond
     public function setConditionString($conditionStrings)
     {
         $this->conditionStrings = $conditionStrings;
-        $this->_functions = array();
+        $this->_functions = [];
 
         foreach ($conditionStrings as $detailType => $conditionString) {
             $this->_functions[$detailType] = $this->create_function('$string,$fromIndex,$toIndex,$node,$s',

--- a/src/GrammarNode/Choice.php
+++ b/src/GrammarNode/Choice.php
@@ -6,7 +6,7 @@ class Choice extends \ParserGenerator\GrammarNode\BaseNode
 {
     protected $choices;
     protected $tmpNodeName;
-    protected $reduce = array();
+    protected $reduce = [];
 
     public function __construct($choices)
     {
@@ -15,13 +15,13 @@ class Choice extends \ParserGenerator\GrammarNode\BaseNode
 
         $this->grammarNode = new \ParserGenerator\GrammarNode\Branch($this->tmpNodeName);
 
-        $node = array();
+        $node = [];
         foreach ($choices as $choice) {
             if (is_array($choice)) {
                 $node[] = $choice;
                 $this->reduce[] = false;
             } else {
-                $node[] = array($choice);
+                $node[] = [$choice];
                 $this->reduce[] = true;
             }
         };
@@ -29,7 +29,7 @@ class Choice extends \ParserGenerator\GrammarNode\BaseNode
         $this->grammarNode->setNode($node);
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         if ($rparseResult = $this->grammarNode->rparse($string, $fromIndex, $restrictedEnd)) {
             if ($this->reduce[$rparseResult['node']->getDetailType()]) {

--- a/src/GrammarNode/LeafTime.php
+++ b/src/GrammarNode/LeafTime.php
@@ -19,7 +19,7 @@ class LeafTime extends \ParserGenerator\GrammarNode\BaseNode implements \ParserG
         $this->eatWhiteChars = $eatWhiteChars;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         $s = substr($string, $fromIndex, $this->maxLength);
         $data = date_parse_from_format($this->format, $s);
@@ -59,6 +59,6 @@ class LeafTime extends \ParserGenerator\GrammarNode\BaseNode implements \ParserG
             $this->lastMatch = $fromIndex;
         }
 
-        return array('node' => $node, 'offset' => $end);
+        return ['node' => $node, 'offset' => $end];
     }
 } 

--- a/src/GrammarNode/Lookahead.php
+++ b/src/GrammarNode/Lookahead.php
@@ -17,22 +17,22 @@ class Lookahead extends \ParserGenerator\GrammarNode\BaseNode
         $this->positive = $positive;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         if ($this->mainNode === null) {
             if (isset($restrictedEnd[$fromIndex])) {
                 return false;
             }
 
-            $match = $this->lookaheadNode->rparse($string, $fromIndex, array()) !== false;
+            $match = $this->lookaheadNode->rparse($string, $fromIndex, []) !== false;
 
             if ($match === $this->positive) {
-                return array('node' => new \ParserGenerator\SyntaxTreeNode\Leaf(''), 'offset' => $fromIndex);
+                return ['node' => new \ParserGenerator\SyntaxTreeNode\Leaf(''), 'offset' => $fromIndex];
             } else {
                 return false;
             }
         } elseif ($this->before) {
-            $match = $this->lookaheadNode->rparse($string, $fromIndex, array()) !== false;
+            $match = $this->lookaheadNode->rparse($string, $fromIndex, []) !== false;
 
             if ($match !== $this->positive) {
                 return false;
@@ -40,15 +40,15 @@ class Lookahead extends \ParserGenerator\GrammarNode\BaseNode
 
             return $this->mainNode->rparse($string, $fromIndex, $restrictedEnd);
         } else { // !$this->before
-            while($rparseResult = $this->mainNode->rparse($string, $fromIndex, $restrictedEnd)) {
-                    $offset = $rparseResult['offset'];
-                    $match  = $this->lookaheadNode->rparse($string, $offset, array()) !== false;
+            while ($rparseResult = $this->mainNode->rparse($string, $fromIndex, $restrictedEnd)) {
+                $offset = $rparseResult['offset'];
+                $match = $this->lookaheadNode->rparse($string, $offset, []) !== false;
 
-                    if ($match === $this->positive) {
-                        return $rparseResult;
-                    } else {
-                        $restrictedEnd[$offset] = $offset;
-                    }
+                if ($match === $this->positive) {
+                    return $rparseResult;
+                } else {
+                    $restrictedEnd[$offset] = $offset;
+                }
             }
 
             return false;
@@ -57,7 +57,7 @@ class Lookahead extends \ParserGenerator\GrammarNode\BaseNode
 
     public function getUsedNodes($startWithOnly = false, $onlyPositive = false)
     {
-        $result = array();
+        $result = [];
         if ((!$startWithOnly || $this->before) && (!$onlyPositive || $this->positive)) {
             $result[] = $this->lookaheadNode;
         }

--- a/src/GrammarNode/NaiveBranch.php
+++ b/src/GrammarNode/NaiveBranch.php
@@ -4,7 +4,7 @@ namespace ParserGenerator\GrammarNode;
 
 class NaiveBranch extends \ParserGenerator\GrammarNode\Branch
 {
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         $cacheStr = $fromIndex . '-' . $this->nodeName . '-' . implode(',', $restrictedEnd);
 
@@ -14,12 +14,12 @@ class NaiveBranch extends \ParserGenerator\GrammarNode\Branch
         $this->parser->cache[$cacheStr] = false;
 
         foreach ($this->node as $_optionIndex => $option) {
-            $subnodes = array();
+            $subnodes = [];
             $optionIndex = 0;
-            $indexes = array(-1 => $fromIndex);
+            $indexes = [-1 => $fromIndex];
             $optionCount = count($option);
             //!!! TODO:
-            $restrictedEnds = array(array(), array(), array(), array(), array(), array(), array(), array());
+            $restrictedEnds = [[], [], [], [], [], [], [], []];
             $restrictedEnds[$optionCount - 1] = $restrictedEnd;
             while (true) {
                 $subNode = $option[$optionIndex]->rparse($string, $indexes[$optionIndex - 1],
@@ -39,7 +39,7 @@ class NaiveBranch extends \ParserGenerator\GrammarNode\Branch
             // match
             $index = $indexes[$optionCount - 1];
             $node = new \ParserGenerator\SyntaxTreeNode\Branch($this->nodeShortName, $_optionIndex, $subnodes);
-            $r = array('node' => $node, 'offset' => $index);
+            $r = ['node' => $node, 'offset' => $index];
             $this->parser->cache[$cacheStr] = $r;
             return $r;
         }

--- a/src/GrammarNode/Numeric.php
+++ b/src/GrammarNode/Numeric.php
@@ -19,16 +19,16 @@ class Numeric extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
     protected $formatBin = false;
     protected $eatWhiteChars = false;
 
-    public function __construct($options = array())
+    public function __construct($options = [])
     {
         foreach ($options as $key => $value) {
-            if (in_array($key, array('min', 'max', 'requireFixedCharacters'), true)) {
+            if (in_array($key, ['min', 'max', 'requireFixedCharacters'], true)) {
                 if (is_int($value)) {
                     $this->$key = $value;
                 }
             }
             if (in_array($key,
-                array('formatDec', 'formatHex', 'formatOct', 'formatBin', 'eatWhiteChars', 'allowFixedCharacters'),
+                ['formatDec', 'formatHex', 'formatOct', 'formatBin', 'eatWhiteChars', 'allowFixedCharacters'],
                 true)) {
                 if (is_bool($value)) {
                     $this->$key = $value;
@@ -49,7 +49,7 @@ class Numeric extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
 
     protected function buildRegexes()
     {
-        $this->regexes = array();
+        $this->regexes = [];
 
         if ($this->formatHex) {
             $this->regexes[16] = $this->buildRegexForBaseFormat('1-9a-fA-F', '0x');
@@ -86,14 +86,14 @@ class Numeric extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
         }
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         foreach ($this->regexes as $base => $regex) {
             if (preg_match($regex, $string, $match, 0, $fromIndex)) {
                 if (isset($match[1])) {
                     $offset = strlen($match[$this->eatWhiteChars ? 0 : 1]) + $fromIndex;
                     if (!isset($restrictedEnd[$offset])) {
-                        $value = intval(str_replace(array('0x', '0b'), array('', ''), $match[1]), $base);
+                        $value = intval(str_replace(['0x', '0b'], ['', ''], $match[1]), $base);
                         if (isset($this->min) && $value < $this->min) {
                             return false;
                         };
@@ -103,7 +103,7 @@ class Numeric extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
 
                         $node = new \ParserGenerator\SyntaxTreeNode\Numeric($match[1], $base);
                         $node->setAfterContent(substr($match[0], strlen($match[1])));
-                        return array('node' => $node, 'offset' => $offset);
+                        return ['node' => $node, 'offset' => $offset];
                     }
                 }
             }

--- a/src/GrammarNode/PEGBranch.php
+++ b/src/GrammarNode/PEGBranch.php
@@ -4,17 +4,17 @@ namespace ParserGenerator\GrammarNode;
 
 class PEGBranch extends \ParserGenerator\GrammarNode\Branch
 {
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         $cacheStr = $fromIndex . '-' . $this->nodeName;
 
         if (!isset($this->parser->cache[$cacheStr])) {
             foreach ($this->node as $_optionIndex => $option) {
                 $index = $fromIndex;
-                $subnodes = array();
+                $subnodes = [];
 
                 foreach ($option as $sequenceItem) {
-                    $subnode = $sequenceItem->rparse($string, $index, array());
+                    $subnode = $sequenceItem->rparse($string, $index, []);
                     if ($subnode) {
                         $subnodes[] = $subnode['node'];
                         $index = $subnode['offset'];
@@ -24,7 +24,7 @@ class PEGBranch extends \ParserGenerator\GrammarNode\Branch
                 }
 
                 $node = new \ParserGenerator\SyntaxTreeNode\Branch($this->nodeShortName, $_optionIndex, $subnodes);
-                $r = array('node' => $node, 'offset' => $index);
+                $r = ['node' => $node, 'offset' => $index];
                 $this->parser->cache[$cacheStr] = $r;
                 return isset($restrictedEnd[$index]) ? false : $r;
             }

--- a/src/GrammarNode/ParameterNode.php
+++ b/src/GrammarNode/ParameterNode.php
@@ -17,7 +17,7 @@ class ParameterNode extends BaseNode
         $this->parameterName = $parameterName;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         throw new Exception("this function should be never called on this node type");
     }

--- a/src/GrammarNode/ParametrizedNode.php
+++ b/src/GrammarNode/ParametrizedNode.php
@@ -18,7 +18,7 @@ class ParametrizedNode extends BaseNode implements \ParserGenerator\ParserAwareI
         $this->params = $params;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         if (!$this->node) {
             $this->node = $this->createNode();

--- a/src/GrammarNode/PredefinedSimpleString.php
+++ b/src/GrammarNode/PredefinedSimpleString.php
@@ -16,7 +16,7 @@ class PredefinedSimpleString extends \ParserGenerator\GrammarNode\BaseNode Imple
         $this->eatWhiteChars = $eatWhiteChars;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         if (preg_match($this->regex, $string, $match, 0, $fromIndex)) {
             if (isset($match[1])) {
@@ -24,7 +24,7 @@ class PredefinedSimpleString extends \ParserGenerator\GrammarNode\BaseNode Imple
                 if (!isset($restrictedEnd[$offset])) {
                     $node = new \ParserGenerator\SyntaxTreeNode\PredefinedString($match[1], '', true);
                     $node->setAfterContent($this->eatWhiteChars ? substr($match[0], strlen($match[1])) : '');
-                    return array('node' => $node, 'offset' => $offset);
+                    return ['node' => $node, 'offset' => $offset];
                 }
             }
         }

--- a/src/GrammarNode/PredefinedString.php
+++ b/src/GrammarNode/PredefinedString.php
@@ -10,13 +10,13 @@ class PredefinedString extends \ParserGenerator\GrammarNode\BaseNode Implements 
     protected $eatWhiteChars;
     protected $startCharacters;
 
-    public function __construct($eatWhiteChars = false, $startCharacters = array("'", '"'))
+    public function __construct($eatWhiteChars = false, $startCharacters = ["'", '"'])
     {
         $this->eatWhiteChars = $eatWhiteChars;
         $this->startCharacters = $startCharacters;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         $stChar = substr($string, $fromIndex, 1);
         if (in_array($stChar, $this->startCharacters)) {
@@ -39,7 +39,7 @@ class PredefinedString extends \ParserGenerator\GrammarNode\BaseNode Implements 
                         $node = new \ParserGenerator\SyntaxTreeNode\PredefinedString($val,
                             $this->eatWhiteChars ? $match[0] : '');
 
-                        return array('node' => $node, 'offset' => $nextPos + 1);
+                        return ['node' => $node, 'offset' => $nextPos + 1];
                     }
                 }
             }

--- a/src/GrammarNode/Regex.php
+++ b/src/GrammarNode/Regex.php
@@ -31,7 +31,7 @@ class Regex extends \ParserGenerator\GrammarNode\BaseNode Implements \ParserGene
         }
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         if (preg_match($this->regex, $string, $match, 0, $fromIndex)) {
             if (isset($match[1])) {
@@ -43,7 +43,7 @@ class Regex extends \ParserGenerator\GrammarNode\BaseNode Implements \ParserGene
                     if ($this->lastMatch < $fromIndex) {
                         $this->lastMatch = $fromIndex;
                     }
-                    return array('node' => $node, 'offset' => $offset);
+                    return ['node' => $node, 'offset' => $offset];
                 }
             }
         }

--- a/src/GrammarNode/Series.php
+++ b/src/GrammarNode/Series.php
@@ -34,26 +34,26 @@ class Series extends \ParserGenerator\GrammarNode\BranchDecorator
 
         $this->node = new \ParserGenerator\GrammarNode\Branch($this->tmpNodeName);
 
-        $ruleGo = $separator ? array($mainNode, $separator, $this->node) : array($mainNode, $this->node);
-        $ruleStop = array($mainNode);
+        $ruleGo = $separator ? [$mainNode, $separator, $this->node] : [$mainNode, $this->node];
+        $ruleStop = [$mainNode];
 
         if ($greedy) {
-            $node = array('go' => $ruleGo, 'stop' => $ruleStop);
+            $node = ['go' => $ruleGo, 'stop' => $ruleStop];
         } else {
-            $node = array('stop' => $ruleStop, 'go' => $ruleGo);
+            $node = ['stop' => $ruleStop, 'go' => $ruleGo];
         }
 
         $this->node->setNode($node);
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         if ($this->from0 && !$this->greedy && !isset($restrictedEnd[$fromIndex])) {
-            return array(
+            return [
                 'node' => new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, $this->resultDetailType,
-                    array(), (bool)$this->separator),
-                'offset' => $fromIndex
-            );
+                    [], (bool)$this->separator),
+                'offset' => $fromIndex,
+            ];
         }
 
         if ($rparseResult = $this->node->rparse($string, $fromIndex, $restrictedEnd)) {
@@ -62,11 +62,11 @@ class Series extends \ParserGenerator\GrammarNode\BranchDecorator
         }
 
         if ($this->from0 && !isset($restrictedEnd[$fromIndex])) {
-            return array(
+            return [
                 'node' => new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, $this->resultDetailType,
-                    array(), (bool)$this->separator),
-                'offset' => $fromIndex
-            );
+                    [], (bool)$this->separator),
+                'offset' => $fromIndex,
+            ];
         }
 
         return false;
@@ -74,7 +74,7 @@ class Series extends \ParserGenerator\GrammarNode\BranchDecorator
 
     protected function getFlattenNode($ast)
     {
-        $astSubnodes = array();
+        $astSubnodes = [];
         while ($ast->getDetailType() == 'go') {
             $astSubnodes[] = $ast->getSubnode(0);
             if ($this->separator) {
@@ -92,9 +92,9 @@ class Series extends \ParserGenerator\GrammarNode\BranchDecorator
 
     public function getNode()
     {
-        $node = $this->separator ? array(array($this->mainNode, $this->separator)) : array(array($this->mainNode));
+        $node = $this->separator ? [[$this->mainNode, $this->separator]] : [[$this->mainNode]];
         if ($this->from0) {
-            $node[] = array();
+            $node[] = [];
         }
         return $node;
     }
@@ -106,7 +106,7 @@ class Series extends \ParserGenerator\GrammarNode\BranchDecorator
 
     public function __toString()
     {
-        $op = array(array('+', '++'), array('*', '**'));
+        $op = [['+', '++'], ['*', '**']];
         return $this->mainNode . $op[$this->from0][$this->greedy] . ($this->separator ?: '');
     }
 

--- a/src/GrammarNode/Text.php
+++ b/src/GrammarNode/Text.php
@@ -14,13 +14,13 @@ class Text extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGener
         $this->str = $str;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         if (substr($string, $fromIndex, strlen($this->str)) === $this->str ||
             ($this->str === '' && strlen($string) === $fromIndex)) {
             $endPos = $fromIndex + strlen($this->str);
             if (!isset($restrictedEnd[$endPos])) {
-                return array('node' => new \ParserGenerator\SyntaxTreeNode\Leaf($this->str), 'offset' => $endPos);
+                return ['node' => new \ParserGenerator\SyntaxTreeNode\Leaf($this->str), 'offset' => $endPos];
             }
         }
 

--- a/src/GrammarNode/TextS.php
+++ b/src/GrammarNode/TextS.php
@@ -4,7 +4,7 @@ namespace ParserGenerator\GrammarNode;
 
 class TextS extends \ParserGenerator\GrammarNode\Text
 {
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         if (substr($string, $fromIndex, strlen($this->str)) == $this->str ||
             ($this->str === '' && strlen($string) === $fromIndex)) {
@@ -13,7 +13,7 @@ class TextS extends \ParserGenerator\GrammarNode\Text
             $endPos += strlen($match[0]);
             if (!isset($restrictedEnd[$endPos])) {
                 $node = new \ParserGenerator\SyntaxTreeNode\Leaf($this->str, $match[0]);
-                return array('node' => $node, 'offset' => $endPos);
+                return ['node' => $node, 'offset' => $endPos];
             }
         }
 

--- a/src/GrammarNode/Unorder.php
+++ b/src/GrammarNode/Unorder.php
@@ -9,8 +9,8 @@ class Unorder extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
     protected $separator;
     protected $resultType;
     protected $tmpNodeName;
-    protected $choices = array();
-    protected $mod = array();
+    protected $choices = [];
+    protected $mod = [];
 
     public function __construct($separator, $resultType = 'unorder')
     {
@@ -34,13 +34,13 @@ class Unorder extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
     {
         foreach ($this->choices as $key => $choice) {
             if ($left[$key] > 0) {
-                $choiceRestrictedEnd = array();
+                $choiceRestrictedEnd = [];
                 $isRequired = !empty($required[$key]);
                 unset($required[$key]);
                 $left[$key]--;
                 while ($choiceResult = $choice->rparse($string, $fromIndex, $choiceRestrictedEnd)) {
                     $afterChoiceIndex = $choiceResult['offset'];
-                    $separatorRestrictedEnd = array();
+                    $separatorRestrictedEnd = [];
                     while ($separatorResult = $this->separator->rparse($string, $afterChoiceIndex,
                         $separatorRestrictedEnd)) {
                         $afterSeparatorIndex = $separatorResult['offset'];
@@ -60,7 +60,7 @@ class Unorder extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
                 if (empty($required)) {
                     $choiceResult = $choice->rparse($string, $fromIndex, $restrictedEnd);
                     if ($choiceResult) {
-                        return array('nodes' => array($choiceResult['node']), 'offset' => $choiceResult['offset']);
+                        return ['nodes' => [$choiceResult['node']], 'offset' => $choiceResult['offset']];
                     }
                 }
 
@@ -74,9 +74,9 @@ class Unorder extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
         return false;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
-        $required = array();
+        $required = [];
         foreach ($this->choices as $key => $choice) {
             $mod = $this->mod[$key];
             $left[$key] = ($mod == '*' || $mod == '+') ? static::MAX : 1;
@@ -88,7 +88,7 @@ class Unorder extends \ParserGenerator\GrammarNode\BaseNode implements \ParserGe
         if ($result = $this->internalParse($string, $fromIndex, $restrictedEnd, $required, $left)) {
             $node = new \ParserGenerator\SyntaxTreeNode\Series($this->resultType, '', array_reverse($result['nodes']),
                 true);
-            return array('node' => $node, 'offset' => $result['offset']);
+            return ['node' => $node, 'offset' => $result['offset']];
         }
 
         return false;

--- a/src/GrammarNode/WhitespaceContextCheck.php
+++ b/src/GrammarNode/WhitespaceContextCheck.php
@@ -7,14 +7,14 @@ class WhitespaceContextCheck extends BaseNode implements LeafInterface
     protected $char;
 
     /* this schoul be const but PHP don't accept array as const */
-    static protected $whiteCharacters = array(" ", "\n", "\t", "\r");
+    static protected $whiteCharacters = [" ", "\n", "\t", "\r"];
 
     public function __construct($char)
     {
         $this->char = $char;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         $substring = substr($string, $fromIndex, 2);
         if ($substring === "\r\n") {
@@ -32,10 +32,10 @@ class WhitespaceContextCheck extends BaseNode implements LeafInterface
         if (($this->char === null) ? in_array($stringChar, self::$whiteCharacters,
             true) : ($this->char === $stringChar)) {
             if (!isset($restrictedEnd[$fromIndex + $offset])) {
-                return array(
+                return [
                     'node' => new \ParserGenerator\SyntaxTreeNode\Leaf($substring),
-                    'offset' => $fromIndex + $offset
-                );
+                    'offset' => $fromIndex + $offset,
+                ];
             }
         }
 
@@ -47,12 +47,12 @@ class WhitespaceContextCheck extends BaseNode implements LeafInterface
                     $char = "\n";
                 }
                 if ($this->char === null || $char === $this->char) {
-                    return array('node' => new \ParserGenerator\SyntaxTreeNode\Leaf(''), 'offset' => $fromIndex);
+                    return ['node' => new \ParserGenerator\SyntaxTreeNode\Leaf(''), 'offset' => $fromIndex];
                 }
             }
 
             if ($index < 0) {
-                return array('node' => new \ParserGenerator\SyntaxTreeNode\Leaf(''), 'offset' => $fromIndex);
+                return ['node' => new \ParserGenerator\SyntaxTreeNode\Leaf(''), 'offset' => $fromIndex];
             }
         }
 
@@ -61,6 +61,6 @@ class WhitespaceContextCheck extends BaseNode implements LeafInterface
 
     public function __toString()
     {
-        return (string) $this->char;
+        return (string)$this->char;
     }
 }

--- a/src/GrammarNode/WhitespaceNegativeContextCheck.php
+++ b/src/GrammarNode/WhitespaceNegativeContextCheck.php
@@ -7,14 +7,14 @@ class WhitespaceNegativeContextCheck extends \ParserGenerator\GrammarNode\BaseNo
     protected $char;
 
     /* this schoul be const but PHP don't accept array as const */
-    static protected $whiteCharacters = array(" ", "\n", "\t", "\r");
+    static protected $whiteCharacters = [" ", "\n", "\t", "\r"];
 
     public function __construct($char)
     {
         $this->char = $char;
     }
 
-    public function rparse($string, $fromIndex = 0, $restrictedEnd = array())
+    public function rparse($string, $fromIndex = 0, $restrictedEnd = [])
     {
         if (!isset($restrictedEnd[$fromIndex])) {
             $index = $fromIndex;
@@ -24,7 +24,7 @@ class WhitespaceNegativeContextCheck extends \ParserGenerator\GrammarNode\BaseNo
                 }
             }
 
-            return array('node' => new \ParserGenerator\SyntaxTreeNode\Leaf(''), 'offset' => $fromIndex);
+            return ['node' => new \ParserGenerator\SyntaxTreeNode\Leaf(''), 'offset' => $fromIndex];
         }
 
         return false;

--- a/src/GrammarNodeCopier.php
+++ b/src/GrammarNodeCopier.php
@@ -19,7 +19,7 @@ class GrammarNodeCopier
                 return null;
             }
             if (is_array($node)) {
-                $result = array();
+                $result = [];
                 foreach ($node as $index => $subnode) {
                     $result[$index] = $_copy($subnode);
                 }

--- a/src/GrammarParser.php
+++ b/src/GrammarParser.php
@@ -20,9 +20,9 @@ use ParserGenerator\GrammarNode\ErrorTrackDecorator;
 
 class GrammarParser
 {
-    static public $defaultPlugins = array();
+    static public $defaultPlugins = [];
     static protected $instance = null;
-    protected $plugins = array();
+    protected $plugins = [];
     protected $parserSchouldBeRefreshed = true;
     protected $parser = null;
 
@@ -73,9 +73,9 @@ class GrammarParser
         return self::$instance;
     }
 
-    public function buildGrammar($grammarStr, $options = array())
+    public function buildGrammar($grammarStr, $options = [])
     {
-        $grammar = array();
+        $grammar = [];
         $parsedGrammar = $this->getParser()->parse($grammarStr);
 
         if ($parsedGrammar === false) {
@@ -108,7 +108,7 @@ class GrammarParser
         foreach ($grammarBranches as $grammarBranch) {
             if ($grammarBranch->getDetailType() === 'standard') {
                 $branchName = (string)$grammarBranch->findFirst('branchName');
-                $rules = array();
+                $rules = [];
                 foreach ($grammarBranch->findAll('rule') as $rule) {
                     $buildRule = $this->buildRule($grammar, $rule, $options);
                     $ruleName = (string)$rule->findFirst('ruleName');
@@ -150,9 +150,9 @@ class GrammarParser
 
     protected function buildBranchNameNode()
     {
-        $restrictedWords = array('or', 'and', 'contain', 'is', 'text', 'string');
+        $restrictedWords = ['or', 'and', 'contain', 'is', 'text', 'string'];
 
-        $restrictedWordsGrammarNode = array();
+        $restrictedWordsGrammarNode = [];
         foreach ($restrictedWords as $restrictedWord) {
             $restrictedWordsGrammarNode[] = new \ParserGenerator\Extension\ItemRestrictions\Is(new \ParserGenerator\GrammarNode\TextS($restrictedWord));
         }
@@ -168,36 +168,36 @@ class GrammarParser
 
     protected function generateNewParser()
     {
-        $stdGrammarGrammar = array(
-            'start' => array(array(':grammarBranches')),
-            'grammarBranches' => array(
-                'notLast' => array(':grammarBranch', ':comments', ':/\./', ':grammarBranches'),
-                'last' => array(':grammarBranch', ':comments', ':/\.?/', ":comments")
-            ),
-            'grammarBranch' => array('standard' => array(':comments', ':branchName', ':branchType', ':rules')),
-            'branchType' => array(array(''), array('(full)'), array('(naive)'), array('(PEG)')),
-            'rules' => array(
-                'last' => array(':rule'),
-                'notLast' => array(':rule', ':rules')
-            ),
-            'rule' => array('standard' => array(':comments', ':/:/', ':ruleName', ':/=>|:=/', ':sequence')),
-            'ruleName' => array(array(':/([A-Za-z_][0-9A-Za-z_]*)?/')),
-            'sequence' => array(
-                'last' => array(':commentSequenceItem'),
-                'notLast' => array(':commentSequenceItem', ':sequence')
-            ),
-            'comments' => array(array(':comment', ':comments'), array('')),
-            'comment' => array(array(':/\/(\*+)[^*](\s|.)*?\2\//')),
-            'commentSequenceItem' => array(array(':comments', ':sequenceItem')),
-            'sequenceItem' => array( /* rule for branches is added after plugin initalizing because it should have lowest priority */)
-        );
+        $stdGrammarGrammar = [
+            'start' => [[':grammarBranches']],
+            'grammarBranches' => [
+                'notLast' => [':grammarBranch', ':comments', ':/\./', ':grammarBranches'],
+                'last' => [':grammarBranch', ':comments', ':/\.?/', ":comments"],
+            ],
+            'grammarBranch' => ['standard' => [':comments', ':branchName', ':branchType', ':rules']],
+            'branchType' => [[''], ['(full)'], ['(naive)'], ['(PEG)']],
+            'rules' => [
+                'last' => [':rule'],
+                'notLast' => [':rule', ':rules'],
+            ],
+            'rule' => ['standard' => [':comments', ':/:/', ':ruleName', ':/=>|:=/', ':sequence']],
+            'ruleName' => [[':/([A-Za-z_][0-9A-Za-z_]*)?/']],
+            'sequence' => [
+                'last' => [':commentSequenceItem'],
+                'notLast' => [':commentSequenceItem', ':sequence'],
+            ],
+            'comments' => [[':comment', ':comments'], ['']],
+            'comment' => [[':/\/(\*+)[^*](\s|.)*?\2\//']],
+            'commentSequenceItem' => [[':comments', ':sequenceItem']],
+            'sequenceItem' => [ /* rule for branches is added after plugin initalizing because it should have lowest priority */],
+        ];
 
         $grammarGrammar = $stdGrammarGrammar;
         foreach ($this->plugins as $plugin) {
             $grammarGrammar = $plugin->extendGrammar($grammarGrammar);
         }
 
-        $grammarGrammar['branchName'] = array(array($this->buildBranchNameNode()));
+        $grammarGrammar['branchName'] = [[$this->buildBranchNameNode()]];
         $grammarGrammar['sequenceItem']['branch'] = ':branchName';
 
         $this->parser = new \ParserGenerator\Parser($grammarGrammar);
@@ -206,7 +206,7 @@ class GrammarParser
     public function buildRule(&$grammar, $rule, $options)
     {
         if ($rule->getDetailType() === 'standard') {
-            $sequence = array();
+            $sequence = [];
             foreach ($rule->findAll('sequenceItem') as $sequenceItem) {
                 $sequenceItemNode = $this->buildSequenceItem($grammar, $sequenceItem, $options);
                 if (count($sequence)) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -5,7 +5,7 @@ namespace ParserGenerator;
 class Parser
 {
     public $cache;
-    public $grammar = array();
+    public $grammar = [];
 
     public $maxIndex;
     public $expected;
@@ -26,7 +26,7 @@ class Parser
         $this->grammar['string'] = new \ParserGenerator\GrammarNode\PredefinedString(true);
 
         foreach ($grammar as $name => $node) {
-            $grammarNodeOptions = array();
+            $grammarNodeOptions = [];
             foreach ($node as $optionIndex => $option) {
                 foreach ((array)$option as $seqIndex => $seq) {
                     if (is_string($seq)) {
@@ -54,7 +54,7 @@ class Parser
 
     public function iterateOverNodes($callback)
     {
-        $visitedNodes = array();
+        $visitedNodes = [];
         foreach ($this->grammar as $node) {
             $this->_iterateOverNodes($node, $callback, $visitedNodes);
         }
@@ -94,7 +94,7 @@ class Parser
         $this->grammar = \ParserGenerator\GrammarParser::getInstance()->buildGrammar($grammar, $options);
     }
 
-    public function __construct($grammar, $options = array())
+    public function __construct($grammar, $options = [])
     {
         if (is_array($grammar)) {
             $this->buildFromArray($grammar, $options);
@@ -120,8 +120,8 @@ class Parser
                 $node->lastNMatch = -1;
             }
         });
-        $this->cache = array();
-        $restrictedEnd = array();
+        $this->cache = [];
+        $restrictedEnd = [];
         if (!empty($this->options['ignoreWhitespaces'])) {
             $trimmedString = ltrim($string);
             $beforeContent = substr($string, 0, strlen($string) - strlen($trimmedString));
@@ -148,12 +148,12 @@ class Parser
     public function getError()
     {
         $maxMatch = -1;
-        $match = array();
+        $match = [];
         $this->iterateOverNodes(function ($node) use (&$maxMatch, &$match) {
             if ($node instanceof \ParserGenerator\GrammarNode\ErrorTrackDecorator) {
                 if ($maxMatch < $node->getMaxCheck()) {
                     $maxMatch = $node->getMaxCheck();
-                    $match = array();
+                    $match = [];
                 }
 
                 if ($maxMatch === $node->getMaxCheck()) {
@@ -182,25 +182,25 @@ class Parser
         });
 
         if ($maxMatch === -1) {
-            return array(
+            return [
                 'index' => 0,
-                'expected' => array($this->grammar['start'])
-            );
+                'expected' => [$this->grammar['start']],
+            ];
         }
 
-        return array(
+        return [
             'index' => $maxMatch,
-            'expected' => $match
-        );
+            'expected' => $match,
+        ];
     }
 
     public static function getLineAndCharacterFromOffset($str, $offset)
     {
         $lines = preg_split('/(\r\n|\n\r|\r|\n)/', substr($str, 0, $offset));
-        return array(
+        return [
             'line' => count($lines),
-            'char' => strlen($lines[count($lines) - 1]) + 1
-        );
+            'char' => strlen($lines[count($lines) - 1]) + 1,
+        ];
     }
 
     public function getErrorString($str)
@@ -226,7 +226,7 @@ class Parser
 
     public function generalizeErrors($errors)
     {
-        $errorsByHash = array();
+        $errorsByHash = [];
         foreach ($errors as $error) {
             $errorsByHash[spl_object_hash($error)] = $error;
         }

--- a/src/RegexUtil.php
+++ b/src/RegexUtil.php
@@ -4,7 +4,7 @@ namespace ParserGenerator;
 
 class RegexUtil
 {
-    protected static $specialChars = array('\\', '/', '+', '*', '?', '[', ']', '(', ')', '|', '.', '$', '^', '{', '}');
+    protected static $specialChars = ['\\', '/', '+', '*', '?', '[', ']', '(', ')', '|', '.', '$', '^', '{', '}'];
     protected static $instance = 0;
     protected $parser = null;
 
@@ -29,46 +29,46 @@ class RegexUtil
 
     public static function getGrammarArray()
     {
-        return array(
-            'start' => array(array('/', ':regex', '/', ':regexModifiers')),
-            'regexModifiers' => array(':/[imsxeADSUXJu]*/'),
-            'regex' => array(array(':regexLine', '|', ':regex'), ':regexLine'),
-            'regexLine' => array(array(':regexToken', ':regexLine'), ''),
-            'regexToken' => array(
+        return [
+            'start' => [['/', ':regex', '/', ':regexModifiers']],
+            'regexModifiers' => [':/[imsxeADSUXJu]*/'],
+            'regex' => [[':regexLine', '|', ':regex'], ':regexLine'],
+            'regexLine' => [[':regexToken', ':regexLine'], ''],
+            'regexToken' => [
                 ':startMatcher',
                 ':endMatcher',
                 ':lookAround',
-                array(':singleStatement', ':repetition', ':nonGreedy')
-            ),
-            'lookAround' => array(array('(?', ':lookArroundType', ':regex', ')')),
-            'lookArroundType' => array('=', '!', '<=', '<!'),
-            'singleStatement' => array(
-                array('(?:', ':regex', ')'),
-                array('(', ':regex', ')'),
-                array('[', ':characterSet', ']'),
-                array('[^', ':characterSet', ']'),
-                array('.'),
-                array(':character')
-            ),
-            'characterSet' => array(
-                array(':simpleCharacter', '-', ':simpleCharacter', ':characterSet'),
-                array(':character', ':characterSet'),
-                ''
-            ),
-            'character' => array(array(':/\\\\./'), ':simpleCharacter'),
-            'simpleCharacter' => array(':/[^\\\\\\]\\[\\+\\*\\?\\|\\(\\)\\$\\^\\/]/'),
-            'repetition' => array(
+                [':singleStatement', ':repetition', ':nonGreedy'],
+            ],
+            'lookAround' => [['(?', ':lookArroundType', ':regex', ')']],
+            'lookArroundType' => ['=', '!', '<=', '<!'],
+            'singleStatement' => [
+                ['(?:', ':regex', ')'],
+                ['(', ':regex', ')'],
+                ['[', ':characterSet', ']'],
+                ['[^', ':characterSet', ']'],
+                ['.'],
+                [':character'],
+            ],
+            'characterSet' => [
+                [':simpleCharacter', '-', ':simpleCharacter', ':characterSet'],
+                [':character', ':characterSet'],
+                '',
+            ],
+            'character' => [[':/\\\\./'], ':simpleCharacter'],
+            'simpleCharacter' => [':/[^\\\\\\]\\[\\+\\*\\?\\|\\(\\)\\$\\^\\/]/'],
+            'repetition' => [
                 '?',
                 '+',
                 '*',
-                array('{', ':/\d+/', '}'),
-                array('{', ':/\d+/', ',', ':/\d*/', '}'),
-                ''
-            ),
-            'nonGreedy' => array('?', ''),
-            'startMatcher' => array('^'),
-            'endMatcher' => array('$'),
-        );
+                ['{', ':/\d+/', '}'],
+                ['{', ':/\d+/', ',', ':/\d*/', '}'],
+                '',
+            ],
+            'nonGreedy' => ['?', ''],
+            'startMatcher' => ['^'],
+            'endMatcher' => ['$'],
+        ];
     }
 
     public function getParser()
@@ -161,7 +161,7 @@ class RegexUtil
     {
         switch ($node->getType()) {
             case 'regex':
-                return $this->_getStartCharacters($node->getSubnode(0)) + ($node->getSubnode(2) ? $this->_getStartCharacters($node->getSubnode(2)) : array());
+                return $this->_getStartCharacters($node->getSubnode(0)) + ($node->getSubnode(2) ? $this->_getStartCharacters($node->getSubnode(2)) : []);
 
             case 'regexLine':
                 if ($node->getDetailType() === 0) {
@@ -171,11 +171,11 @@ class RegexUtil
                         return $this->_getStartCharacters($node->getSubnode(0));
                     }
                 } elseif ($node->getDetailType() === 1) {
-                    return array();
+                    return [];
                 }
 
             case 'regexToken':
-                return ($node->getDetailType() !== 3) ? array() : $this->_getStartCharacters($node->getSubnode(0));
+                return ($node->getDetailType() !== 3) ? [] : $this->_getStartCharacters($node->getSubnode(0));
 
             case 'singleStatement':
                 if ($node->getDetailType() === 0 || $node->getDetailType() === 1 || $node->getDetailType() === 2) {
@@ -185,14 +185,14 @@ class RegexUtil
                 } elseif ($node->getDetailType() === 5) {
                     return $this->_getStartCharacters($node->getSubnode(0));
                 } elseif ($node->getDetailType() === 4) {
-                    return $this->getReverseCharSet(array("\n"));
+                    return $this->getReverseCharSet(["\n"]);
                 }
 
             case 'character':
                 if ($node->getDetailType() === 0) {
                     switch ((string)$node) {
                         case '\\s':
-                            return array("\n" => true, "\r" => true, " " => true, "\t" => true);
+                            return ["\n" => true, "\r" => true, " " => true, "\t" => true];
                         case '\\d':
                             return $this->getCharacterRange('0', '9');
                         case '\\w':
@@ -211,14 +211,14 @@ class RegexUtil
                         case '\\.':
                         case '\\$':
                         case '\\^':
-                            $result = array();
+                            $result = [];
                             $result[substr((string)$node, 1, 1)] = true;
                             return $result;
                         default:
                             throw new Exception("Unknown character group [$node]");
                     }
                 } else {
-                    $result = array();
+                    $result = [];
                     $result[(string)$node] = true;
                     return $result;
                 }
@@ -234,7 +234,7 @@ class RegexUtil
                     case 1:
                         return $this->_getStartCharacters($node->getSubnode(0)) + $this->_getStartCharacters($node->getSubnode(1));
                     case 2:
-                        return array();
+                        return [];
                 }
             default:
                 return true;
@@ -243,7 +243,7 @@ class RegexUtil
 
     protected function getReverseCharSet($charSet)
     {
-        $result = array();
+        $result = [];
         for ($i = 0; $i < 256; $i++) {
             if (empty($charSet[chr($i)])) {
                 $result[chr($i)] = true;
@@ -255,7 +255,7 @@ class RegexUtil
 
     protected function getCharacterRange($from, $to)
     {
-        $result = array();
+        $result = [];
         for ($i = ord((string)$from); $i <= ord((string)$to); $i++) {
             $result[chr($i)] = true;
         }
@@ -289,21 +289,21 @@ class RegexUtil
         //'repetition' => array('?', '+', '*', array('{', ':/\d+/', '}'), array('{', ':/\d+/', ',', ':/\d*/', '}'), '');
         switch ($node->getDetailType()) {
             case 0:
-                return array('min' => 0, 'max' => 1);
+                return ['min' => 0, 'max' => 1];
             case 1:
-                return array('min' => 1);
+                return ['min' => 1];
             case 2:
-                return array('min' => 0);
+                return ['min' => 0];
             case 3:
                 $o = (int)(string)$node->getSubnode(1);
-                return array('min' => $o, 'max' => $o);
+                return ['min' => $o, 'max' => $o];
             case 4:
                 $min = (int)(string)$node->getSubnode(1);
                 $maxStr = (string)$node->getSubnode(3);
                 $max = $maxStr ? (int)$maxStr : null;
-                return array('min' => $min, 'max' => $max);
+                return ['min' => $min, 'max' => $max];
         }
-        return array('min' => 1, 'max' => 1);
+        return ['min' => 1, 'max' => 1];
     }
 
     protected function _generateString($node)

--- a/src/SyntaxTreeNode/Branch.php
+++ b/src/SyntaxTreeNode/Branch.php
@@ -8,9 +8,9 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
 {
     protected $type;
     protected $detailType;
-    protected $subnodes = array();
+    protected $subnodes = [];
 
-    public function __construct($type, $detailType, $subnodes = array())
+    public function __construct($type, $detailType, $subnodes = [])
     {
         $this->type = $type;
         $this->detailType = $detailType;
@@ -126,7 +126,7 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
 
     public function getLeafs()
     {
-        $result = array();
+        $result = [];
         foreach ($this->subnodes as $subnode) {
             if ($subnode instanceof \ParserGenerator\SyntaxTreeNode\Branch) {
                 $result = array_merge($result, $subnode->getLeafs());
@@ -147,7 +147,7 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
 
     public function findAll($type, $nest = false, $childrenFirst = false)
     {
-        $result = array();
+        $result = [];
 
         if ($this->is($type) && !$childrenFirst) {
             $result[] = $this;
@@ -278,12 +278,12 @@ class Branch extends \ParserGenerator\SyntaxTreeNode\Base
         ) {
 
             if ($returnAsPair) {
-                return array(array($this, $anotherNode));
+                return [[$this, $anotherNode]];
             } else {
-                return array($this);
+                return [$this];
             }
         } else {
-            $result = array();
+            $result = [];
 
             foreach ($this->subnodes as $index => $subnode) {
                 $result = array_merge($result, $subnode->diff($anotherNode->subnodes[$index], $returnAsPair));

--- a/src/SyntaxTreeNode/Leaf.php
+++ b/src/SyntaxTreeNode/Leaf.php
@@ -73,12 +73,12 @@ class Leaf extends \ParserGenerator\SyntaxTreeNode\Base
     public function diff($anotherNode, $returnAsPair = true)
     {
         if ($this->content === $anotherNode->content) {
-            return array();
+            return [];
         } else {
             if ($returnAsPair) {
-                return array(array($this, $anotherNode));
+                return [[$this, $anotherNode]];
             } else {
-                return array($this);
+                return [$this];
             }
         }
     }

--- a/src/SyntaxTreeNode/Numeric.php
+++ b/src/SyntaxTreeNode/Numeric.php
@@ -19,7 +19,7 @@ class Numeric extends \ParserGenerator\SyntaxTreeNode\Leaf
 
     public function getFixedCharacters()
     {
-        $str = str_replace(array('0x', '0b'), array('', ''), $this->content);
+        $str = str_replace(['0x', '0b'], ['', ''], $this->content);
 
         if (substr($str, 0, 1) === '-') {
             $str = substr($str, 1);
@@ -38,7 +38,7 @@ class Numeric extends \ParserGenerator\SyntaxTreeNode\Leaf
 
     public function getValue()
     {
-        $str = str_replace(array('0x', '0b'), array('', ''), $this->content);
+        $str = str_replace(['0x', '0b'], ['', ''], $this->content);
         return intval($str, $this->base);
     }
 }

--- a/src/SyntaxTreeNode/PredefinedString.php
+++ b/src/SyntaxTreeNode/PredefinedString.php
@@ -27,7 +27,7 @@ class PredefinedString extends \ParserGenerator\SyntaxTreeNode\Leaf
         if (substr($this->content, 0, 1) === '"') {
             return stripcslashes(substr(str_replace("\\'", "\\\\'", $this->content), 1, -1));
         } else {
-            return str_replace(array('\\\\', '\\\''), array('\\', '\''), substr($this->content, 1, -1));
+            return str_replace(['\\\\', '\\\''], ['\\', '\''], substr($this->content, 1, -1));
         }
     }
 }

--- a/src/SyntaxTreeNode/Root.php
+++ b/src/SyntaxTreeNode/Root.php
@@ -6,7 +6,7 @@ class Root extends \ParserGenerator\SyntaxTreeNode\Branch
 {
     protected $beforeContent = '';
 
-    public function __construct($type, $detailType, $subnodes = array(), $beforeContent = '')
+    public function __construct($type, $detailType, $subnodes = [], $beforeContent = '')
     {
         parent::__construct($type, $detailType, $subnodes);
         $this->beforeContent = $beforeContent;

--- a/src/SyntaxTreeNode/Series.php
+++ b/src/SyntaxTreeNode/Series.php
@@ -6,7 +6,7 @@ class Series extends \ParserGenerator\SyntaxTreeNode\Branch
 {
     protected $isWithSeparator;
 
-    public function __construct($type, $detailType, $subnodes = array(), $isWithSeparator = false)
+    public function __construct($type, $detailType, $subnodes = [], $isWithSeparator = false)
     {
         parent::__construct($type, $detailType, $subnodes);
         $this->isWithSeparator = $isWithSeparator;
@@ -19,7 +19,7 @@ class Series extends \ParserGenerator\SyntaxTreeNode\Branch
         }
 
         $subnodesCount = count($this->subnodes);
-        $result = array();
+        $result = [];
 
         for ($i = 0; $i < $subnodesCount; $i += 2) {
             $result[] = $this->subnodes[$i];
@@ -31,11 +31,11 @@ class Series extends \ParserGenerator\SyntaxTreeNode\Branch
     public function getSeparators()
     {
         if (!$this->isWithSeparator) {
-            return array();
+            return [];
         }
 
         $subnodesCount = count($this->subnodes);
-        $result = array();
+        $result = [];
 
         for ($i = 1; $i < $subnodesCount; $i += 2) {
             $result[] = $this->subnodes[$i];
@@ -72,7 +72,7 @@ class Series extends \ParserGenerator\SyntaxTreeNode\Branch
 
     public function findFirstInMainNodes($type, $addNullValues = false)
     {
-        $result = array();
+        $result = [];
 
         foreach ($this->getMainNodes() as $node) {
             if ($node instanceof \ParserGenerator\SyntaxTreeNode\Branch) {

--- a/tests/Examples/CSVParserTest.php
+++ b/tests/Examples/CSVParserTest.php
@@ -10,10 +10,10 @@ class CSVParserTest extends TestCase
     {
         $parser = new \ParserGenerator\Examples\CSVParser();
 
-        $expected = array(
-            array('r1c1', 'r1c2'),
-            array('r2c1', 'r2c2')
-        );
+        $expected = [
+            ['r1c1', 'r1c2'],
+            ['r2c1', 'r2c2'],
+        ];
 
         $this->assertEquals($expected, $parser->parseCSV("r1c1,r1c2\nr2c1,r2c2"));
     }
@@ -22,10 +22,10 @@ class CSVParserTest extends TestCase
     {
         $parser = new \ParserGenerator\Examples\CSVParser();
 
-        $expected = array(
-            array('r1c1', 'r1c2'),
-            array('r2c1', 'r2c2')
-        );
+        $expected = [
+            ['r1c1', 'r1c2'],
+            ['r2c1', 'r2c2'],
+        ];
 
         $this->assertEquals($expected, $parser->parseCSV("\"r1c1\" , \"r1c2\"\n\"r2c1\",\"r2c2\""));
     }
@@ -34,9 +34,9 @@ class CSVParserTest extends TestCase
     {
         $parser = new \ParserGenerator\Examples\CSVParser();
 
-        $expected = array(
-            array('  c1  ', ' c2 ')
-        );
+        $expected = [
+            ['  c1  ', ' c2 '],
+        ];
 
         $this->assertEquals($expected, $parser->parseCSV("  c1  , c2 "));
     }
@@ -45,10 +45,10 @@ class CSVParserTest extends TestCase
     {
         $parser = new \ParserGenerator\Examples\CSVParser();
 
-        $expected = array(
-            array('text "quot"', ", \n"),
-            array('\n', 'a')
-        );
+        $expected = [
+            ['text "quot"', ", \n"],
+            ['\n', 'a'],
+        ];
 
         $this->assertEquals($expected, $parser->parseCSV("\"text \"\"quot\"\"\", \", \n\" \n  \"\\n\",a"));
     }

--- a/tests/Examples/JSONParserTest.php
+++ b/tests/Examples/JSONParserTest.php
@@ -21,23 +21,23 @@ class JSONParserTest extends TestCase
     public function testArray()
     {
         $jsonParser = new \ParserGenerator\Examples\JSONParser();
-        $this->assertEquals(array(), $jsonParser->getValue('[]'));
-        $this->assertEquals(array(true), $jsonParser->getValue('[true]'));
-        $this->assertEquals(array(1, 2, 3), $jsonParser->getValue('[1, 2, 3]'));
-        $this->assertEquals(array("1, 2", "3"), $jsonParser->getValue('["1, 2", "3"]'));
-        $this->assertEquals(array(array(), array(array())), $jsonParser->getValue('[[],[[]]]'));
-        $this->assertEquals(array(array("a1", "a2"), array("b1", "b2")),
+        $this->assertEquals([], $jsonParser->getValue('[]'));
+        $this->assertEquals([true], $jsonParser->getValue('[true]'));
+        $this->assertEquals([1, 2, 3], $jsonParser->getValue('[1, 2, 3]'));
+        $this->assertEquals(["1, 2", "3"], $jsonParser->getValue('["1, 2", "3"]'));
+        $this->assertEquals([[], [[]]], $jsonParser->getValue('[[],[[]]]'));
+        $this->assertEquals([["a1", "a2"], ["b1", "b2"]],
             $jsonParser->getValue('[["a1", "a2"], ["b1", "b2"]]'));
     }
 
     public function testObject()
     {
         $jsonParser = new \ParserGenerator\Examples\JSONParser();
-        $this->assertEquals(array(), $jsonParser->getValue('{}'));
-        $this->assertEquals(array("x" => "x"), $jsonParser->getValue('{"x":"x"}'));
-        $this->assertEquals(array("x" => 4, "y" => 5, "color" => "red", "visible" => true),
+        $this->assertEquals([], $jsonParser->getValue('{}'));
+        $this->assertEquals(["x" => "x"], $jsonParser->getValue('{"x":"x"}'));
+        $this->assertEquals(["x" => 4, "y" => 5, "color" => "red", "visible" => true],
             $jsonParser->getValue('{"x": 4, "y": 5, "color":"red", "visible":true}'));
-        $this->assertEquals(array("a" => array(), "b" => array("c" => "c")),
+        $this->assertEquals(["a" => [], "b" => ["c" => "c"]],
             $jsonParser->getValue('{"a" : {}, "b":{"c": "c"}}'));
 
     }
@@ -45,6 +45,6 @@ class JSONParserTest extends TestCase
     public function testMixed()
     {
         $jsonParser = new \ParserGenerator\Examples\JSONParser();
-        $this->assertEquals(array("x" => array(array("c" => "c"), 6)), $jsonParser->getValue('{"x":[{"c":"c"}, 6]}'));
+        $this->assertEquals(["x" => [["c" => "c"], 6]], $jsonParser->getValue('{"x":[{"c":"c"}, 6]}'));
     }
 }

--- a/tests/Examples/PostfixToInfixNotationTranslatorTest.php
+++ b/tests/Examples/PostfixToInfixNotationTranslatorTest.php
@@ -16,7 +16,7 @@ class PostfixToInfixNotationTranslatorTest extends TestCase
                      :=> "-"
                      :=> "*"
                      :=> "/".
-        ', array('ignoreWhitespaces' => true));
+        ', ['ignoreWhitespaces' => true]);
 
         $tree = $parser->parse($str);
 
@@ -30,7 +30,7 @@ class PostfixToInfixNotationTranslatorTest extends TestCase
             $node->setSubnode(2, $temp);
 
             if ($parent && in_array((string)$node->getSubnode(1),
-                    array('+', '-')) && in_array((string)$parent->getSubnode(2), array('*', '/'))) {
+                    ['+', '-']) && in_array((string)$parent->getSubnode(2), ['*', '/'])) {
                 return '(' . $node . ')';
             }
         });

--- a/tests/Examples/YamlLikeIndentationParserTest.php
+++ b/tests/Examples/YamlLikeIndentationParserTest.php
@@ -10,11 +10,11 @@ class YamlLikeIndentationParserTest extends TestCase
     {
         $parser = new \ParserGenerator\Examples\YamlLikeIndentationParser();
 
-        $this->assertEquals(array("a" => "x"), $parser->getValue("a:x"));
-        $this->assertEquals(array(
+        $this->assertEquals(["a" => "x"], $parser->getValue("a:x"));
+        $this->assertEquals([
             "a" => "x",
-            "b" => "y"
-        ), $parser->getValue("
+            "b" => "y",
+        ], $parser->getValue("
             a:x
             b:y"));
     }
@@ -23,11 +23,11 @@ class YamlLikeIndentationParserTest extends TestCase
     {
         $parser = new \ParserGenerator\Examples\YamlLikeIndentationParser();
 
-        $this->assertEquals(array(
-            "a" => array(
-                "b" => "x"
-            )
-        ), $parser->getValue("
+        $this->assertEquals([
+            "a" => [
+                "b" => "x",
+            ],
+        ], $parser->getValue("
             a:
              b:x"));
     }
@@ -36,11 +36,11 @@ class YamlLikeIndentationParserTest extends TestCase
     {
         $parser = new \ParserGenerator\Examples\YamlLikeIndentationParser();
 
-        $this->assertEquals(array(
-            "a" => array(
-                "b" => "x"
-            )
-        ), $parser->getValue("
+        $this->assertEquals([
+            "a" => [
+                "b" => "x",
+            ],
+        ], $parser->getValue("
             a:
                          b:x"));
     }
@@ -49,17 +49,17 @@ class YamlLikeIndentationParserTest extends TestCase
     {
         $parser = new \ParserGenerator\Examples\YamlLikeIndentationParser();
 
-        $this->assertEquals(array(
-            "a" => array(
-                "b" => array(
-                    "c" => array(
-                        "d" => array(
-                            "e" => "x"
-                        )
-                    )
-                )
-            )
-        ), $parser->getValue("
+        $this->assertEquals([
+            "a" => [
+                "b" => [
+                    "c" => [
+                        "d" => [
+                            "e" => "x",
+                        ],
+                    ],
+                ],
+            ],
+        ], $parser->getValue("
             a:
               b:
                 c:
@@ -71,40 +71,40 @@ class YamlLikeIndentationParserTest extends TestCase
     {
         $parser = new \ParserGenerator\Examples\YamlLikeIndentationParser();
 
-        $this->assertEquals(array(
-            "a" => array(
-                "b" => array(
+        $this->assertEquals([
+            "a" => [
+                "b" => [
                     "c" => "x",
-                    "d" => "y"
-                )
-            )
-        ), $parser->getValue("
+                    "d" => "y",
+                ],
+            ],
+        ], $parser->getValue("
             a:
               b:
                 c:x
                 d:y"));
 
-        $this->assertEquals(array(
-            "a" => array(
-                "b" => array(
-                    "c" => "x"
-                ),
-                "d" => "y"
-            )
-        ), $parser->getValue("
+        $this->assertEquals([
+            "a" => [
+                "b" => [
+                    "c" => "x",
+                ],
+                "d" => "y",
+            ],
+        ], $parser->getValue("
             a:
               b:
                 c:x
               d:y"));
 
-        $this->assertEquals(array(
-            "a" => array(
-                "b" => array(
-                    "c" => "x"
-                )
-            ),
-            "d" => "y"
-        ), $parser->getValue("
+        $this->assertEquals([
+            "a" => [
+                "b" => [
+                    "c" => "x",
+                ],
+            ],
+            "d" => "y",
+        ], $parser->getValue("
             a:
               b:
                 c:x
@@ -129,30 +129,30 @@ class YamlLikeIndentationParserTest extends TestCase
     {
         $parser = new \ParserGenerator\Examples\YamlLikeIndentationParser();
 
-        $this->assertEquals(array(
-            "a" => array(
-                "b" => array(
+        $this->assertEquals([
+            "a" => [
+                "b" => [
                     "c" => "1",
-                    "d" => "2"
-                ),
-                "e" => array(
-                    "f" => array(
+                    "d" => "2",
+                ],
+                "e" => [
+                    "f" => [
                         "g" => "3",
-                        "h" => "4"
-                    )
-                ),
+                        "h" => "4",
+                    ],
+                ],
                 "i" => "5",
                 "j" => "6",
-                "k" => array(
-                    "l" => array(
-                        "m" => "7"
-                    ),
+                "k" => [
+                    "l" => [
+                        "m" => "7",
+                    ],
                     "n" => "8",
-                    "o" => "9"
-                ),
-                "p" => "10"
-            )
-        ), $parser->getValue("
+                    "o" => "9",
+                ],
+                "p" => "10",
+            ],
+        ], $parser->getValue("
             a:
               b:
                 c:1

--- a/tests/Extension/ChoiceTest.php
+++ b/tests/Extension/ChoiceTest.php
@@ -31,21 +31,21 @@ class ChoiceTest extends TestCase
         $x = new Parser('start :=> (abc | "z" | /[qwe]/) "." .
                          abc   :=> "abc".');
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
             new \ParserGenerator\SyntaxTreeNode\Branch('abc', 0,
-                array(new \ParserGenerator\SyntaxTreeNode\Leaf('abc'))),
+                [new \ParserGenerator\SyntaxTreeNode\Leaf('abc')]),
             new \ParserGenerator\SyntaxTreeNode\Leaf('.'),
-        )), $x->parse("abc."));
+        ]), $x->parse("abc."));
     }
 
     public function testOnAmbigousGrammarChoiceSchouldPickFirstOption()
     {
         $x = new Parser('start :=> ("a" | "b" | "bc") /.*/ .');
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
             new \ParserGenerator\SyntaxTreeNode\Leaf('b'),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('cd')
-        )), $x->parse('bcd'));
+            new \ParserGenerator\SyntaxTreeNode\Leaf('cd'),
+        ]), $x->parse('bcd'));
     }
 
     public function testWithSeries()
@@ -57,60 +57,60 @@ class ChoiceTest extends TestCase
         $this->assertFalse($x->parse(''));
         $this->assertFalse($x->parse('abc'));
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Series('list', '', array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Series('list', '', [
                 new \ParserGenerator\SyntaxTreeNode\Branch('a', 0,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('a')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('b', 0,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('b')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('a', 0,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('a')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('b', 0,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
-                new \ParserGenerator\SyntaxTreeNode\Branch('b', 0, array(new \ParserGenerator\SyntaxTreeNode\Leaf('b')))
-            ), false)
-        )), $x->parse('ababb'));
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('b')]),
+                new \ParserGenerator\SyntaxTreeNode\Branch('b', 0, [new \ParserGenerator\SyntaxTreeNode\Leaf('b')]),
+            ], false),
+        ]), $x->parse('ababb'));
     }
 
     public function testSeries()
     {
         $x = new Parser('start :=> ("a" | "b" "c" | "c" ?"d" | "d"++) /.+/.');
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
             new \ParserGenerator\SyntaxTreeNode\Leaf('a'),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('a')
-        )), $x->parse('aa'));
+            new \ParserGenerator\SyntaxTreeNode\Leaf('a'),
+        ]), $x->parse('aa'));
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
             new \ParserGenerator\SyntaxTreeNode\Leaf('c'),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('de')
-        )), $x->parse('cde'));
+            new \ParserGenerator\SyntaxTreeNode\Leaf('de'),
+        ]), $x->parse('cde'));
 
         $parsed = $x->parse('bce');
         $this->assertTrue((bool)$parsed->getSubnode(0)->getType());
         $parsed->getSubnode(0)->setType('');
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Branch('', 1, array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Branch('', 1, [
                 new \ParserGenerator\SyntaxTreeNode\Leaf('b'),
-                new \ParserGenerator\SyntaxTreeNode\Leaf('c')
-            )),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('e')
-        )), $parsed);
+                new \ParserGenerator\SyntaxTreeNode\Leaf('c'),
+            ]),
+            new \ParserGenerator\SyntaxTreeNode\Leaf('e'),
+        ]), $parsed);
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Series('list', 'd', array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Series('list', 'd', [
                 new \ParserGenerator\SyntaxTreeNode\Leaf('d'),
-                new \ParserGenerator\SyntaxTreeNode\Leaf('d')
-            )),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('e')
-        )), $x->parse('dde'));
+                new \ParserGenerator\SyntaxTreeNode\Leaf('d'),
+            ]),
+            new \ParserGenerator\SyntaxTreeNode\Leaf('e'),
+        ]), $x->parse('dde'));
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Series('list', 'd', array(
-                new \ParserGenerator\SyntaxTreeNode\Leaf('d')
-            )),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('e')
-        )), $x->parse('de'));
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Series('list', 'd', [
+                new \ParserGenerator\SyntaxTreeNode\Leaf('d'),
+            ]),
+            new \ParserGenerator\SyntaxTreeNode\Leaf('e'),
+        ]), $x->parse('de'));
     }
 }

--- a/tests/Extension/ItemRestrictions/ContainTest.php
+++ b/tests/Extension/ItemRestrictions/ContainTest.php
@@ -15,32 +15,32 @@ class ContainTest extends TestCase
         $contain = new \ParserGenerator\Extension\ItemRestrictions\Contain($x->grammar['start']);
 
         $this->assertFalse($contain->check('qwerty', 0, 3, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('abcdef', 0, 6, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('aabcdef', 0, 7, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertFalse($contain->check('abcdef', 1, 6, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('aabcdef', 1, 7, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertFalse($contain->check('abcdef', 0, 1, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('abcd', 0, 3, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('ab', 0, 2, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('ab   ', 0, 5, null));
 
         $x = new Parser("start :=> 'abcd'
-                               :=> 'ab'.", array('ignoreWhitespaces' => true));
+                               :=> 'ab'.", ['ignoreWhitespaces' => true]);
 
         $contain = new \ParserGenerator\Extension\ItemRestrictions\Contain($x->grammar['start']);
 
         $this->assertTrue($contain->check('ab  ', 0, 4, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('ab  ', 0, 3, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('ab  ', 0, 2, null));
     }
 }

--- a/tests/Extension/ItemRestrictions/IsTest.php
+++ b/tests/Extension/ItemRestrictions/IsTest.php
@@ -15,22 +15,22 @@ class IsTest extends TestCase
         $contain = new \ParserGenerator\Extension\ItemRestrictions\Is($x->grammar['start']);
 
         $this->assertFalse($contain->check('qwerty', 0, 3, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('xabcd', 1, 5, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertFalse($contain->check('xabcf', 1, 5, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('xabcf', 1, 3, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertFalse($contain->check('xabcd', 1, 4, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('ab', 0, 2, null));
-        $x->cache = array();
+        $x->cache = [];
         $this->assertTrue($contain->check('ab  ', 0, 2, null));
-        $x->cache = array();
+        $x->cache = [];
 
         $x = new Parser("start :=> 'abcd'
-                               :=> 'ab'.", array('ignoreWhitespaces' => true));
+                               :=> 'ab'.", ['ignoreWhitespaces' => true]);
 
         $contain = new \ParserGenerator\Extension\ItemRestrictions\Is($x->grammar['start']);
 

--- a/tests/Extension/ItemRestrictionsTest.php
+++ b/tests/Extension/ItemRestrictionsTest.php
@@ -37,20 +37,20 @@ class ItemRestrictionsTest extends TestCase
         $this->assertFalse($x->parse('aac'));
         $this->assertFalse($x->parse('ab'));
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf("aa"),
-            new Leaf("b")
-        )), $x->parse("aab"));
+            new Leaf("b"),
+        ]), $x->parse("aab"));
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf("sdabag"),
-            new Leaf("b")
-        )), $x->parse("sdabagb"));
+            new Leaf("b"),
+        ]), $x->parse("sdabagb"));
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf("ba"),
-            new Leaf("b")
-        )), $x->parse("bab"));
+            new Leaf("b"),
+        ]), $x->parse("bab"));
 
         $x = new Parser('start :=> text contain /[ab]{2}/ text.');
 
@@ -59,20 +59,20 @@ class ItemRestrictionsTest extends TestCase
         $this->assertFalse($x->parse('a'));
         $this->assertFalse($x->parse(''));
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf("ba"),
-            new Leaf("b")
-        )), $x->parse("bab"));
+            new Leaf("b"),
+        ]), $x->parse("bab"));
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf("xba"),
-            new Leaf("bb")
-        )), $x->parse("xbabb"));
+            new Leaf("bb"),
+        ]), $x->parse("xbabb"));
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf("xba"),
-            new Leaf("xbbxaa")
-        )), $x->parse("xbaxbbxaa"));
+            new Leaf("xbbxaa"),
+        ]), $x->parse("xbaxbbxaa"));
     }
 
     public function testWithNodes()
@@ -202,10 +202,10 @@ class ItemRestrictionsTest extends TestCase
     {
         $x = new Parser('start :=> (text contain ?"aaa") text.');
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf("qaaba"),
-            new Leaf("aacaaaa")
-        )), $x->parse("qaabaaacaaaa"));
+            new Leaf("aacaaaa"),
+        ]), $x->parse("qaabaaacaaaa"));
     }
 
     public function testWithLookaround()
@@ -272,14 +272,14 @@ class ItemRestrictionsTest extends TestCase
 
         $x = new Parser('start :=> text followed by "a" text.');
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf("qw"),
-            new Leaf("adgahaab")
-        )), $x->parse("qwadgahaab"));
+            new Leaf("adgahaab"),
+        ]), $x->parse("qwadgahaab"));
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf(""),
-            new Leaf("aaa")
-        )), $x->parse("aaa"));
+            new Leaf("aaa"),
+        ]), $x->parse("aaa"));
     }
 }

--- a/tests/Extension/LookaheadTest.php
+++ b/tests/Extension/LookaheadTest.php
@@ -74,9 +74,9 @@ class LookaheadTest extends TestCase
     {
         $x = new Parser('start :=> ?/[abc]/ /.+/ .');
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Leaf('abc')
-        )), $x->parse("abc"));
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Leaf('abc'),
+        ]), $x->parse("abc"));
 
         $x = new Parser('start :=> ?abc /.+/ .
                          abc   :=> a b c.
@@ -84,9 +84,9 @@ class LookaheadTest extends TestCase
                          b     :=> "b".
                          c     :=> "c".');
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Leaf('abc')
-        )), $x->parse("abc"));
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Leaf('abc'),
+        ]), $x->parse("abc"));
     }
 
     public function testInsideChoice()
@@ -96,22 +96,22 @@ class LookaheadTest extends TestCase
         $this->assertFalse($x->parse('acd'));
         $this->assertFalse($x->parse(''));
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
             new \ParserGenerator\SyntaxTreeNode\Leaf('ab'),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('de')
-        )), $x->parse("abde"));
+            new \ParserGenerator\SyntaxTreeNode\Leaf('de'),
+        ]), $x->parse("abde"));
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
             new \ParserGenerator\SyntaxTreeNode\Leaf('a'),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('bce')
-        )), $x->parse("abce"));
+            new \ParserGenerator\SyntaxTreeNode\Leaf('bce'),
+        ]), $x->parse("abce"));
 
         $x = new Parser('start :=> (?"abc" | "bc")  /.*/ .');
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
             new \ParserGenerator\SyntaxTreeNode\Leaf(''),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('abce')
-        )), $x->parse("abce"));
+            new \ParserGenerator\SyntaxTreeNode\Leaf('abce'),
+        ]), $x->parse("abce"));
     }
 
     public function testAnBnCnGrammar()

--- a/tests/Extension/ParametrizedNodeTest.php
+++ b/tests/Extension/ParametrizedNodeTest.php
@@ -152,12 +152,12 @@ class ParametrizedNodeTest extends TestCase
             return array_map('strval', $parsed->getSubnode(0)->getMainNodes());
         };
 
-        $this->assertEquals(array("11", "11"), $toList("1111"));
-        $this->assertEquals(array("1010", "11"), $toList("101011"));
-        $this->assertEquals(array("10110101", "0010"), $toList("101101010010"));
-        $this->assertEquals(array("1001001111", "11011", "1011100"), $toList("1001001111110111011100"));
-        $this->assertEquals(array("11111101111010"), $toList("11111101111010"));
-        $this->assertEquals(array("1111110111", "1110"), $toList("11111101111110"));
+        $this->assertEquals(["11", "11"], $toList("1111"));
+        $this->assertEquals(["1010", "11"], $toList("101011"));
+        $this->assertEquals(["10110101", "0010"], $toList("101101010010"));
+        $this->assertEquals(["1001001111", "11011", "1011100"], $toList("1001001111110111011100"));
+        $this->assertEquals(["11111101111010"], $toList("11111101111010"));
+        $this->assertEquals(["1111110111", "1110"], $toList("11111101111110"));
 
         $this->assertFalse($x->parse("0000000000000"));
         $this->assertFalse($x->parse("1001001"));

--- a/tests/Extension/RuleConditionTest.php
+++ b/tests/Extension/RuleConditionTest.php
@@ -15,7 +15,7 @@ class RuleConditionTest extends TestCase
     public function testIntegers()
     {
         $x = new Parser('start :=> 1..100 1..100 <? $s[0]->getValue() < $s[1]->getValue() ?>.',
-            array('ignoreWhitespaces' => true));
+            ['ignoreWhitespaces' => true]);
         $this->assertObject($x->parse('36 45'));
         $this->assertObject($x->parse('1 100'));
         $this->assertObject($x->parse('1 2'));

--- a/tests/Extension/SeriesTest.php
+++ b/tests/Extension/SeriesTest.php
@@ -26,20 +26,20 @@ class SeriesTest extends TestCase
         $this->assertObject($x->parse('abacab'));
         $this->assertFalse($x->parse(''));
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Series('list', 'str', array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Series('list', 'str', [
                 new \ParserGenerator\SyntaxTreeNode\Branch('str', 0,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('a')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('str', 1,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('b')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('str', 0,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('a')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('str', 2,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('c'))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('c')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('str', 0,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
-            ), false)
-        )), $x->parse("abaca"));
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('a')]),
+            ], false),
+        ]), $x->parse("abaca"));
     }
 
     public function testMWithoutSeparator()
@@ -55,9 +55,9 @@ class SeriesTest extends TestCase
         $this->assertObject($x->parse('b'));
         $this->assertObject($x->parse('abacab'));
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Series('list', 'str', array(), false)
-        )), $x->parse(''));
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Series('list', 'str', [], false),
+        ]), $x->parse(''));
     }
 
     public function testWithSeparator()
@@ -73,20 +73,20 @@ class SeriesTest extends TestCase
         $this->assertObject($x->parse('b,a'));
         $this->assertFalse($x->parse(''));
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Series('list', 'str', array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Series('list', 'str', [
                 new \ParserGenerator\SyntaxTreeNode\Branch('str', 0,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('a'))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('a')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('coma', 0,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf(','))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf(',')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('str', 2,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('c'))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('c')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('coma', 0,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf(','))),
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf(',')]),
                 new \ParserGenerator\SyntaxTreeNode\Branch('str', 1,
-                    array(new \ParserGenerator\SyntaxTreeNode\Leaf('b'))),
-            ), true)
-        )), $x->parse("a,c,b"));
+                    [new \ParserGenerator\SyntaxTreeNode\Leaf('b')]),
+            ], true),
+        ]), $x->parse("a,c,b"));
     }
 
     public function testWithVariousTypes()
@@ -137,23 +137,23 @@ class SeriesTest extends TestCase
 
         $x = new Parser('start :=> /./+  /.*/ .');
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Series('list', '/./', array(
-                new \ParserGenerator\SyntaxTreeNode\Leaf('a')
-            ), false),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('bc')
-        )), $x->parse("abc"));
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Series('list', '/./', [
+                new \ParserGenerator\SyntaxTreeNode\Leaf('a'),
+            ], false),
+            new \ParserGenerator\SyntaxTreeNode\Leaf('bc'),
+        ]), $x->parse("abc"));
 
         $x = new Parser('start :=> /./++  /.*/ .');
 
-        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, array(
-            new \ParserGenerator\SyntaxTreeNode\Series('list', '/./', array(
+        $this->assertEquals(new \ParserGenerator\SyntaxTreeNode\Root('start', 0, [
+            new \ParserGenerator\SyntaxTreeNode\Series('list', '/./', [
                 new \ParserGenerator\SyntaxTreeNode\Leaf('a'),
                 new \ParserGenerator\SyntaxTreeNode\Leaf('b'),
-                new \ParserGenerator\SyntaxTreeNode\Leaf('c')
-            ), false),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('')
-        )), $x->parse("abc"));
+                new \ParserGenerator\SyntaxTreeNode\Leaf('c'),
+            ], false),
+            new \ParserGenerator\SyntaxTreeNode\Leaf(''),
+        ]), $x->parse("abc"));
     }
 
     public function testSurrounded()
@@ -166,7 +166,7 @@ class SeriesTest extends TestCase
 
     public function testSeriesInPegAreAlwaysGreedy()
     {
-        $x = new Parser('start :=> "a"+', array('defaultBranchType' => 'PEG'));
+        $x = new Parser('start :=> "a"+', ['defaultBranchType' => 'PEG']);
 
         $this->assertObject($x->parse('aaa'));
     }

--- a/tests/Extension/TextTest.php
+++ b/tests/Extension/TextTest.php
@@ -17,39 +17,39 @@ class TextTest extends TestCase
 
     public function testBaseText()
     {
-        $x = new Parser('start :=> text.', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> text.', ['ignoreWhitespaces' => true]);
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Leaf("Lorem ipsum dolor\nsit emet")
-        )), $x->parse("Lorem ipsum dolor\nsit emet"));
+        $this->assertEquals(new Root('start', 0, [
+            new Leaf("Lorem ipsum dolor\nsit emet"),
+        ]), $x->parse("Lorem ipsum dolor\nsit emet"));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Leaf("")
-        ), ' '), $x->parse(" "));
+        $this->assertEquals(new Root('start', 0, [
+            new Leaf(""),
+        ], ' '), $x->parse(" "));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Leaf("")
-        )), $x->parse(""));
+        $this->assertEquals(new Root('start', 0, [
+            new Leaf(""),
+        ]), $x->parse(""));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Leaf("Lorem ipsum", "\n")
-        ), ' '), $x->parse(" Lorem ipsum\n"));
+        $this->assertEquals(new Root('start', 0, [
+            new Leaf("Lorem ipsum", "\n"),
+        ], ' '), $x->parse(" Lorem ipsum\n"));
 
-        $x = new Parser('start :=> text.', array('ignoreWhitespaces' => false));
+        $x = new Parser('start :=> text.', ['ignoreWhitespaces' => false]);
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Leaf("")
-        )), $x->parse(""));
+        $this->assertEquals(new Root('start', 0, [
+            new Leaf(""),
+        ]), $x->parse(""));
 
-        $x = new Parser('start :=> text++",".', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> text++",".', ['ignoreWhitespaces' => true]);
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Series('list', 'text', array(
+        $this->assertEquals(new Root('start', 0, [
+            new Series('list', 'text', [
                 new Leaf('some text', ' '),
                 new Leaf(',', ' '),
-                new Leaf('more text')
-            ), true)
-        )), $x->parse("some text , more text"));
+                new Leaf('more text'),
+            ], true),
+        ]), $x->parse("some text , more text"));
 
         $parsed = $x->parse("a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a");
 

--- a/tests/Extension/TimeTest.php
+++ b/tests/Extension/TimeTest.php
@@ -57,7 +57,7 @@ class TimeTest extends TestCase
 
     public function testDataShouldProperlyCaptureWhitespaces()
     {
-        $x = new Parser('start :=> time(Y-m-d) text.', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> time(Y-m-d) text.', ['ignoreWhitespaces' => true]);
 
         $timeNode = $x->parse('2014-03-08  lorem ipsum')->getSubnode(0);
         $this->assertEquals('2014-03-08  ',

--- a/tests/Extension/WhiteCharactersTest.php
+++ b/tests/Extension/WhiteCharactersTest.php
@@ -26,7 +26,7 @@ class WhiteCharactersTest extends TestCase
         $this->assertObject($x->parse("x\r\nx"));
         $this->assertObject($x->parse("x\rx"));
 
-        $x = new Parser('start :=> "x"+newLine.', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> "x"+newLine.', ['ignoreWhitespaces' => true]);
 
         $this->assertObject($x->parse("x\nx"));
         $this->assertObject($x->parse("x\r\nx"));

--- a/tests/GrammarNodes/GrammarNodeNumericTest.php
+++ b/tests/GrammarNodes/GrammarNodeNumericTest.php
@@ -16,50 +16,50 @@ class GrammarNodeNumericTest extends TestCase
     {
         $x = new \ParserGenerator\GrammarNode\Numeric();
 
-        $this->assertNodeEquals('5', $x->rparse('5b123vb', 0, array()));
-        $this->assertNodeEquals('123', $x->rparse('5b123vb', 2, array()));
-        $this->assertNodeEquals('-123', $x->rparse('5b-123vb', 2, array()));
-        $this->assertFalse($x->rparse('ab123vb', 2, array(5 => 5)));
-        $this->assertNodeEquals('0', $x->rparse('ab0x3vb', 2, array()));
-        $this->assertFalse($x->rparse('ab0x3vb', 2, array(3 => 3)));
+        $this->assertNodeEquals('5', $x->rparse('5b123vb', 0, []));
+        $this->assertNodeEquals('123', $x->rparse('5b123vb', 2, []));
+        $this->assertNodeEquals('-123', $x->rparse('5b-123vb', 2, []));
+        $this->assertFalse($x->rparse('ab123vb', 2, [5 => 5]));
+        $this->assertNodeEquals('0', $x->rparse('ab0x3vb', 2, []));
+        $this->assertFalse($x->rparse('ab0x3vb', 2, [3 => 3]));
     }
 
     public function testBase()
     {
-        $x = new \ParserGenerator\GrammarNode\Numeric(array('formatHex' => true));
+        $x = new \ParserGenerator\GrammarNode\Numeric(['formatHex' => true]);
 
-        $this->assertNodeEquals('123', $x->rparse('ab123vb', 2, array()));
-        $this->assertFalse($x->rparse('ab123vb', 2, array(5 => 5)));
-        $this->assertNodeEquals('0x3', $x->rparse('ab0x3vb', 2, array()));
-        $this->assertNodeEquals('0', $x->rparse('ab0x3vb', 2, array(5 => 5)));
-        $this->assertFalse($x->rparse('ab0x3vb', 2, array(3 => 3, 5 => 5)));
+        $this->assertNodeEquals('123', $x->rparse('ab123vb', 2, []));
+        $this->assertFalse($x->rparse('ab123vb', 2, [5 => 5]));
+        $this->assertNodeEquals('0x3', $x->rparse('ab0x3vb', 2, []));
+        $this->assertNodeEquals('0', $x->rparse('ab0x3vb', 2, [5 => 5]));
+        $this->assertFalse($x->rparse('ab0x3vb', 2, [3 => 3, 5 => 5]));
     }
 
     public function testMinMax()
     {
-        $x = new \ParserGenerator\GrammarNode\Numeric(array(
+        $x = new \ParserGenerator\GrammarNode\Numeric([
             'formatHex' => true,
             'formatBin' => true,
             'min' => 7,
-            'max' => 250
-        ));
+            'max' => 250,
+        ]);
 
-        $this->assertFalse($x->rparse('-8', 0, array()));
-        $this->assertFalse($x->rparse('6', 0, array()));
-        $this->assertFalse($x->rparse('251', 0, array()));
-        $this->assertFalse($x->rparse('1000', 0, array()));
-        $this->assertFalse($x->rparse('5000', 0, array()));
-        $this->assertNodeEquals('7', $x->rparse('7', 0, array()));
-        $this->assertNodeEquals('90', $x->rparse('90', 0, array()));
-        $this->assertNodeEquals('57', $x->rparse('57', 0, array()));
-        $this->assertNodeEquals('250', $x->rparse('250', 0, array()));
-        $this->assertNodeEquals('0x7', $x->rparse('0x7', 0, array()));
-        $this->assertNodeEquals('0xfa', $x->rparse('0xfa', 0, array()));
-        $this->assertFalse($x->rparse('0x250', 0, array()));
-        $this->assertFalse($x->rparse('0xfb', 0, array()));
-        $this->assertFalse($x->rparse('0x110', 0, array()));
-        $this->assertNodeEquals('0b111', $x->rparse('0b111', 0, array()));
-        $this->assertNodeEquals('0b11111010', $x->rparse('0b11111010', 0, array()));
-        $this->assertFalse($x->rparse('0b11111011', 0, array()));
+        $this->assertFalse($x->rparse('-8', 0, []));
+        $this->assertFalse($x->rparse('6', 0, []));
+        $this->assertFalse($x->rparse('251', 0, []));
+        $this->assertFalse($x->rparse('1000', 0, []));
+        $this->assertFalse($x->rparse('5000', 0, []));
+        $this->assertNodeEquals('7', $x->rparse('7', 0, []));
+        $this->assertNodeEquals('90', $x->rparse('90', 0, []));
+        $this->assertNodeEquals('57', $x->rparse('57', 0, []));
+        $this->assertNodeEquals('250', $x->rparse('250', 0, []));
+        $this->assertNodeEquals('0x7', $x->rparse('0x7', 0, []));
+        $this->assertNodeEquals('0xfa', $x->rparse('0xfa', 0, []));
+        $this->assertFalse($x->rparse('0x250', 0, []));
+        $this->assertFalse($x->rparse('0xfb', 0, []));
+        $this->assertFalse($x->rparse('0x110', 0, []));
+        $this->assertNodeEquals('0b111', $x->rparse('0b111', 0, []));
+        $this->assertNodeEquals('0b11111010', $x->rparse('0b11111010', 0, []));
+        $this->assertFalse($x->rparse('0b11111011', 0, []));
     }
 }

--- a/tests/ParsedNodes/BranchTest.php
+++ b/tests/ParsedNodes/BranchTest.php
@@ -18,14 +18,14 @@ class BranchTest extends TestCase
 {
     public function testCopy()
     {
-        $b = new Root('x', 0, array(
+        $b = new Root('x', 0, [
             new Leaf('leaf1'),
-            new Branch('b1', 0, array(
+            new Branch('b1', 0, [
                 new Leaf('leaf1.1'),
-                new Leaf('leaf1.2')
-            )),
-            new Numeric('23', 10)
-        ));
+                new Leaf('leaf1.2'),
+            ]),
+            new Numeric('23', 10),
+        ]);
 
         $b->refreshOwners();
 

--- a/tests/ParsedNodes/ParserNodeTest.php
+++ b/tests/ParsedNodes/ParserNodeTest.php
@@ -8,12 +8,12 @@ class ParserNodeTest extends TestCase
 {
     public function testClone()
     {
-        $a = new \ParserGenerator\SyntaxTreeNode\Branch('a', 'b', array(
-            new \ParserGenerator\SyntaxTreeNode\Branch('q', 'w', array(
-                new \ParserGenerator\SyntaxTreeNode\Leaf('l1')
-            )),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('l2')
-        ));
+        $a = new \ParserGenerator\SyntaxTreeNode\Branch('a', 'b', [
+            new \ParserGenerator\SyntaxTreeNode\Branch('q', 'w', [
+                new \ParserGenerator\SyntaxTreeNode\Leaf('l1'),
+            ]),
+            new \ParserGenerator\SyntaxTreeNode\Leaf('l2'),
+        ]);
 
         $b = clone $a;
 
@@ -26,12 +26,12 @@ class ParserNodeTest extends TestCase
 
     public function testToString()
     {
-        $a = new \ParserGenerator\SyntaxTreeNode\Branch('a', 'b', array(
-            new \ParserGenerator\SyntaxTreeNode\Branch('q', 'w', array(
-                new \ParserGenerator\SyntaxTreeNode\Leaf('l1')
-            )),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('l2')
-        ));
+        $a = new \ParserGenerator\SyntaxTreeNode\Branch('a', 'b', [
+            new \ParserGenerator\SyntaxTreeNode\Branch('q', 'w', [
+                new \ParserGenerator\SyntaxTreeNode\Leaf('l1'),
+            ]),
+            new \ParserGenerator\SyntaxTreeNode\Leaf('l2'),
+        ]);
 
         $this->assertEquals('l1l2', (string)$a);
 
@@ -50,12 +50,12 @@ class ParserNodeTest extends TestCase
 
     public function testCompare()
     {
-        $a = new \ParserGenerator\SyntaxTreeNode\Branch('a', 'b', array(
-            new \ParserGenerator\SyntaxTreeNode\Branch('q', 'w', array(
-                new \ParserGenerator\SyntaxTreeNode\Leaf('l1')
-            )),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('l2')
-        ));
+        $a = new \ParserGenerator\SyntaxTreeNode\Branch('a', 'b', [
+            new \ParserGenerator\SyntaxTreeNode\Branch('q', 'w', [
+                new \ParserGenerator\SyntaxTreeNode\Leaf('l1'),
+            ]),
+            new \ParserGenerator\SyntaxTreeNode\Leaf('l2'),
+        ]);
 
         $b = clone $a;
 
@@ -91,65 +91,65 @@ class ParserNodeTest extends TestCase
 
     protected function getTestNode1()
     {
-        return new \ParserGenerator\SyntaxTreeNode\Branch('a', '', array(
-            new \ParserGenerator\SyntaxTreeNode\Branch('b', '', array(
+        return new \ParserGenerator\SyntaxTreeNode\Branch('a', '', [
+            new \ParserGenerator\SyntaxTreeNode\Branch('b', '', [
                 new \ParserGenerator\SyntaxTreeNode\Leaf('l1'),
-                new \ParserGenerator\SyntaxTreeNode\Branch('b', '', array(
-                    new \ParserGenerator\SyntaxTreeNode\Branch('c', '', array(
-                        new \ParserGenerator\SyntaxTreeNode\Leaf('l2')
-                    )),
-                    new \ParserGenerator\SyntaxTreeNode\Branch('b', '', array(
+                new \ParserGenerator\SyntaxTreeNode\Branch('b', '', [
+                    new \ParserGenerator\SyntaxTreeNode\Branch('c', '', [
+                        new \ParserGenerator\SyntaxTreeNode\Leaf('l2'),
+                    ]),
+                    new \ParserGenerator\SyntaxTreeNode\Branch('b', '', [
                         new \ParserGenerator\SyntaxTreeNode\Leaf('l3'),
-                        new \ParserGenerator\SyntaxTreeNode\Leaf('l4')
-                    ))
-                ))
-            )),
+                        new \ParserGenerator\SyntaxTreeNode\Leaf('l4'),
+                    ]),
+                ]),
+            ]),
             new \ParserGenerator\SyntaxTreeNode\Leaf('l2'),
-            new \ParserGenerator\SyntaxTreeNode\Branch('c', '', array(
-                new \ParserGenerator\SyntaxTreeNode\Branch('b', '', array()),
-                new \ParserGenerator\SyntaxTreeNode\Branch('d', '', array(
-                    new \ParserGenerator\SyntaxTreeNode\Leaf('l5')
-                ))
-            ))
-        ));
+            new \ParserGenerator\SyntaxTreeNode\Branch('c', '', [
+                new \ParserGenerator\SyntaxTreeNode\Branch('b', '', []),
+                new \ParserGenerator\SyntaxTreeNode\Branch('d', '', [
+                    new \ParserGenerator\SyntaxTreeNode\Leaf('l5'),
+                ]),
+            ]),
+        ]);
     }
 
     public function testFindAll()
     {
         $a = $this->getTestNode1();
 
-        $this->assertEquals(array($a), $a->findAll('a'));
+        $this->assertEquals([$a], $a->findAll('a'));
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             $a->getSubnode(0)->getSubnode(1)->getSubnode(0),
-            $a->getSubnode(2)
-        ), $a->findAll('c'));
+            $a->getSubnode(2),
+        ], $a->findAll('c'));
 
-        $this->assertEquals(array(
-            $a->getSubnode(2)->getSubnode(1)
-        ), $a->findAll('d'));
+        $this->assertEquals([
+            $a->getSubnode(2)->getSubnode(1),
+        ], $a->findAll('d'));
 
-        $this->assertEquals(array(), $a->findAll('nonExistingType'));
-        $this->assertEquals(array(), $a->findAll('nonExistingType', true));
-        $this->assertEquals(array(), $a->findAll('nonExistingType', true, true));
+        $this->assertEquals([], $a->findAll('nonExistingType'));
+        $this->assertEquals([], $a->findAll('nonExistingType', true));
+        $this->assertEquals([], $a->findAll('nonExistingType', true, true));
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             $a->getSubnode(0),
-            $a->getSubnode(2)->getSubnode(0)
-        ), $a->findAll('b'));
+            $a->getSubnode(2)->getSubnode(0),
+        ], $a->findAll('b'));
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             $a->getSubnode(0),
             $a->getSubnode(0)->getSubnode(1),
             $a->getSubnode(0)->getSubnode(1)->getSubnode(1),
-            $a->getSubnode(2)->getSubnode(0)
-        ), $a->findAll('b', true));
+            $a->getSubnode(2)->getSubnode(0),
+        ], $a->findAll('b', true));
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             $a->getSubnode(0)->getSubnode(1)->getSubnode(1),
             $a->getSubnode(0)->getSubnode(1),
             $a->getSubnode(0),
-            $a->getSubnode(2)->getSubnode(0)
-        ), $a->findAll('b', true, true));
+            $a->getSubnode(2)->getSubnode(0),
+        ], $a->findAll('b', true, true));
     }
 }

--- a/tests/ParsedNodes/SeriesTest.php
+++ b/tests/ParsedNodes/SeriesTest.php
@@ -22,11 +22,11 @@ class SeriesTest extends TestCase
         $seriesNode = $x->parse('8,12,4')->getSubnode(0);
 
         $this->assertTrue($seriesNode instanceof \ParserGenerator\SyntaxTreeNode\Series);
-        $this->assertEquals(array(
+        $this->assertEquals([
             new \ParserGenerator\SyntaxTreeNode\Leaf('8'),
             new \ParserGenerator\SyntaxTreeNode\Leaf('12'),
-            new \ParserGenerator\SyntaxTreeNode\Leaf('4')
-        ), $seriesNode->getMainNodes());
+            new \ParserGenerator\SyntaxTreeNode\Leaf('4'),
+        ], $seriesNode->getMainNodes());
     }
 
     public function testOrderBy()

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -27,12 +27,12 @@ class ParserTest extends TestCase
 
     public function testSuperSimple()
     {
-        $x = new Parser(array(
-            'start' => array('cat', 'dog')
-        ));
+        $x = new Parser([
+            'start' => ['cat', 'dog'],
+        ]);
 
-        $this->assertEquals(new Root('start', 0, array(new Leaf('cat'))), $x->parse('cat'));
-        $this->assertEquals(new Root('start', 1, array(new Leaf('dog'))), $x->parse('dog'));
+        $this->assertEquals(new Root('start', 0, [new Leaf('cat')]), $x->parse('cat'));
+        $this->assertEquals(new Root('start', 1, [new Leaf('dog')]), $x->parse('dog'));
         $this->assertEquals(false, $x->parse(''));
         $this->assertEquals(false, $x->parse('totalywrong'));
         $this->assertEquals(false, $x->parse(' cat'));
@@ -44,9 +44,9 @@ class ParserTest extends TestCase
 
     public function testWithEmptyOption()
     {
-        $x = new Parser(array(
-            'start' => array('', 'aaa')
-        ));
+        $x = new Parser([
+            'start' => ['', 'aaa'],
+        ]);
 
         $this->assertObject($x->parse(''));
         $this->assertObject($x->parse('aaa'));
@@ -56,22 +56,22 @@ class ParserTest extends TestCase
     public function testOneNamedNode()
     {
 
-        $x = new Parser(array(
-            'start' => array(':animal'),
-            'animal' => array('cat', 'dog')
-        ));
+        $x = new Parser([
+            'start' => [':animal'],
+            'animal' => ['cat', 'dog'],
+        ]);
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('animal', 0, array(
-                new Leaf('cat')
-            ))
-        )), $x->parse('cat'));
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('animal', 0, [
+                new Leaf('cat'),
+            ]),
+        ]), $x->parse('cat'));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('animal', 1, array(
-                new Leaf('dog')
-            ))
-        )), $x->parse('dog'));
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('animal', 1, [
+                new Leaf('dog'),
+            ]),
+        ]), $x->parse('dog'));
 
         $this->assertEquals(false, $x->parse(''));
         $this->assertEquals(false, $x->parse('totalywrong'));
@@ -84,40 +84,40 @@ class ParserTest extends TestCase
 
     public function testEndRecursion()
     {
-        $x = new Parser(array(
-            'start' => array(':bs'),
-            'bs' => array(array('b', ':bs'), '')
-        ));
+        $x = new Parser([
+            'start' => [':bs'],
+            'bs' => [['b', ':bs'], ''],
+        ]);
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('bs', 1, array(
-                new Leaf('')
-            ))
-        )), $x->parse(''));
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('bs', 1, [
+                new Leaf(''),
+            ]),
+        ]), $x->parse(''));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('bs', 0, array(
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('bs', 0, [
                 new Leaf('b'),
-                new Branch('bs', 1, array(
-                    new Leaf('')
-                ))
-            ))
-        )), $x->parse('b'));
+                new Branch('bs', 1, [
+                    new Leaf(''),
+                ]),
+            ]),
+        ]), $x->parse('b'));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('bs', 0, array(
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('bs', 0, [
                 new Leaf('b'),
-                new Branch('bs', 0, array(
+                new Branch('bs', 0, [
                     new Leaf('b'),
-                    new Branch('bs', 0, array(
+                    new Branch('bs', 0, [
                         new Leaf('b'),
-                        new Branch('bs', 1, array(
-                            new Leaf('')
-                        ))
-                    ))
-                ))
-            ))
-        )), $x->parse('bbb'));
+                        new Branch('bs', 1, [
+                            new Leaf(''),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ]), $x->parse('bbb'));
 
         $this->assertEquals(false, $x->parse('bbb-bbb'));
         $this->assertEquals(false, $x->parse('c'));
@@ -126,40 +126,40 @@ class ParserTest extends TestCase
 
     public function testSimpleStartRecursion()
     {
-        $x = new Parser(array(
-            'start' => array(':bs'),
-            'bs' => array(array(':bs', 'b'), '')
-        ));
+        $x = new Parser([
+            'start' => [':bs'],
+            'bs' => [[':bs', 'b'], ''],
+        ]);
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('bs', 1, array(
-                new Leaf('')
-            ))
-        )), $x->parse(''));
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('bs', 1, [
+                new Leaf(''),
+            ]),
+        ]), $x->parse(''));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('bs', 0, array(
-                new Branch('bs', 1, array(
-                    new Leaf('')
-                )),
-                new Leaf('b')
-            ))
-        )), $x->parse('b'));
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('bs', 0, [
+                new Branch('bs', 1, [
+                    new Leaf(''),
+                ]),
+                new Leaf('b'),
+            ]),
+        ]), $x->parse('b'));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('bs', 0, array(
-                new Branch('bs', 0, array(
-                    new Branch('bs', 0, array(
-                        new Branch('bs', 1, array(
-                            new Leaf('')
-                        )),
-                        new Leaf('b')
-                    )),
-                    new Leaf('b')
-                )),
-                new Leaf('b')
-            ))
-        )), $x->parse('bbb'));
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('bs', 0, [
+                new Branch('bs', 0, [
+                    new Branch('bs', 0, [
+                        new Branch('bs', 1, [
+                            new Leaf(''),
+                        ]),
+                        new Leaf('b'),
+                    ]),
+                    new Leaf('b'),
+                ]),
+                new Leaf('b'),
+            ]),
+        ]), $x->parse('bbb'));
 
         $this->assertEquals(false, $x->parse('bbb-bbb'));
         $this->assertEquals(false, $x->parse('c'));
@@ -168,41 +168,41 @@ class ParserTest extends TestCase
 
     public function testMultiNodeStartRecursion()
     {
-        $x = new Parser(array(
-            'start' => array(':as'),
-            'as' => array('', array(':bs', 'a')),
-            'bs' => array('', array(':as', 'b'))
-        ));
+        $x = new Parser([
+            'start' => [':as'],
+            'as' => ['', [':bs', 'a']],
+            'bs' => ['', [':as', 'b']],
+        ]);
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('as', 0, array(
-                new Leaf('')
-            ))
-        )), $x->parse(''));
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('as', 0, [
+                new Leaf(''),
+            ]),
+        ]), $x->parse(''));
 
         $this->assertEquals(false, $x->parse('b'));
         $this->assertEquals(false, $x->parse('ab'));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('as', 1, array(
-                new Branch('bs', 0, array(
-                    new Leaf('')
-                )),
-                new Leaf('a')
-            ))
-        )), $x->parse('a'));
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('as', 1, [
+                new Branch('bs', 0, [
+                    new Leaf(''),
+                ]),
+                new Leaf('a'),
+            ]),
+        ]), $x->parse('a'));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('as', 1, array(
-                new Branch('bs', 1, array(
-                    new Branch('as', 0, array(
-                        new Leaf('')
-                    )),
-                    new Leaf('b')
-                )),
-                new Leaf('a')
-            ))
-        )), $x->parse('ba'));
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('as', 1, [
+                new Branch('bs', 1, [
+                    new Branch('as', 0, [
+                        new Leaf(''),
+                    ]),
+                    new Leaf('b'),
+                ]),
+                new Leaf('a'),
+            ]),
+        ]), $x->parse('ba'));
 
         $this->assertEquals(false, $x->parse('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'));
         $this->assertEquals(false, $x->parse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
@@ -211,69 +211,69 @@ class ParserTest extends TestCase
 
     public function testMultiNodeStartRecursionRec()
     {
-        $x = new Parser(array(
-            'start' => array(':as'),
-            'as' => array(array(':bs', 'a'), ''),
-            'bs' => array(array(':as', 'b'), '')
-        ));
+        $x = new Parser([
+            'start' => [':as'],
+            'as' => [[':bs', 'a'], ''],
+            'bs' => [[':as', 'b'], ''],
+        ]);
 
         // TODO: var_dump($x->parse('aba'));
         //var_dump($x->parse('ababababababababababa'));
 
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('as', 0, array(
-                new Branch('bs', 0, array(
-                    new Branch('as', 1, array(
-                        new Leaf('')
-                    )),
-                    new Leaf('b')
-                )),
-                new Leaf('a')
-            ))
-        )), $x->parse('ba'));
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('as', 0, [
+                new Branch('bs', 0, [
+                    new Branch('as', 1, [
+                        new Leaf(''),
+                    ]),
+                    new Leaf('b'),
+                ]),
+                new Leaf('a'),
+            ]),
+        ]), $x->parse('ba'));
     }
 
     public function testSelectFirstMatch()
     {
-        $x = new Parser(array(
-            'start' => array(array('sss'), array('a', 'bbb'), array('abb', 'b')),
-        ));
+        $x = new Parser([
+            'start' => [['sss'], ['a', 'bbb'], ['abb', 'b']],
+        ]);
         $this->assertEquals(1, $x->parse('abbb')->getDetailType());
 
-        $x = new Parser(array(
-            'start' => array(array(':start', 'a'), '', 'aaa')
-        ));
+        $x = new Parser([
+            'start' => [[':start', 'a'], '', 'aaa'],
+        ]);
         $this->assertEquals(0, $x->parse('aaa')->getDetailType());
 
-        $x = new Parser(array(
-            'start' => array(array(':a', ':start'), ''),
-            'a' => array('aa', 'aaa', 'a')
-        ));
-        $this->assertEquals(new Root('start', 0, array(
-            new Branch('a', 0, array(new Leaf('aa'))),
-            new Branch('start', 0, array(
-                new Branch('a', 0, array(new Leaf('aa'))),
-                new Branch('start', 0, array(
-                    new Branch('a', 2, array(new Leaf('a'))),
-                    new Branch('start', 1, array(new Leaf('')))
-                ))
-            ))
-        )), $x->parse('aaaaa'));
+        $x = new Parser([
+            'start' => [[':a', ':start'], ''],
+            'a' => ['aa', 'aaa', 'a'],
+        ]);
+        $this->assertEquals(new Root('start', 0, [
+            new Branch('a', 0, [new Leaf('aa')]),
+            new Branch('start', 0, [
+                new Branch('a', 0, [new Leaf('aa')]),
+                new Branch('start', 0, [
+                    new Branch('a', 2, [new Leaf('a')]),
+                    new Branch('start', 1, [new Leaf('')]),
+                ]),
+            ]),
+        ]), $x->parse('aaaaa'));
 
-        $x = new Parser(array(
-            'start' => array(array(':ab', ':ac')),
-            'ab' => array(array('a', ':ab'), array('b', ':ab'), ''), //greedy
-            'ac' => array(array('a', ':ac'), array('c', ':ac'), '')
-        ));
+        $x = new Parser([
+            'start' => [[':ab', ':ac']],
+            'ab' => [['a', ':ab'], ['b', ':ab'], ''], //greedy
+            'ac' => [['a', ':ac'], ['c', ':ac'], ''],
+        ]);
         $r = $x->parse('abbaaaacac');
         $this->assertEquals('abbaaaa', (string)$r->getSubnode(0));
         $this->assertEquals('cac', (string)$r->getSubnode(1));
 
-        $x = new Parser(array(
-            'start' => array(array(':ab', ':ac')),
-            'ab' => array('', array('a', ':ab'), array('b', ':ab')), //non greedy
-            'ac' => array('', array('a', ':ac'), array('c', ':ac'))
-        ));
+        $x = new Parser([
+            'start' => [[':ab', ':ac']],
+            'ab' => ['', ['a', ':ab'], ['b', ':ab']], //non greedy
+            'ac' => ['', ['a', ':ac'], ['c', ':ac']],
+        ]);
         $r = $x->parse('abbaaaacac');
         $this->assertEquals('abb', (string)$r->getSubnode(0));
         $this->assertEquals('aaaacac', (string)$r->getSubnode(1));
@@ -281,9 +281,9 @@ class ParserTest extends TestCase
 
     public function testCheckingPredefinedString()
     {
-        $x = new Parser(array(
-            'start' => array(array(':string'))
-        ));
+        $x = new Parser([
+            'start' => [[':string']],
+        ]);
 
         $this->assertObject($x->parse("'dddffff'"));
         $this->assertFalse($x->parse("a'dddffff'"));
@@ -307,9 +307,9 @@ class ParserTest extends TestCase
 
     public function testCheckingRegexMatching()
     {
-        $x = new Parser(array(
-            'start' => array(':/a+b?/')
-        ));
+        $x = new Parser([
+            'start' => [':/a+b?/'],
+        ]);
 
         $this->assertObject($x->parse('aaaaaaa'));
         $this->assertObject($x->parse('aaab'));
@@ -318,9 +318,9 @@ class ParserTest extends TestCase
         $this->assertFalse($x->parse('a aaab'));
         $this->assertFalse($x->parse(' aaaa'));
 
-        $x = new Parser(array(
-            'start' => array(array(':/(aaa)?/'))
-        ));
+        $x = new Parser([
+            'start' => [[':/(aaa)?/']],
+        ]);
         $this->assertObject($x->parse('aaa'));
         $this->assertObject($x->parse(''));
         $this->assertFalse($x->parse('a'));
@@ -328,27 +328,27 @@ class ParserTest extends TestCase
         $this->assertFalse($x->parse('aaaa'));
         $this->assertFalse($x->parse('baaa'));
 
-        $x = new Parser(array(
-            'start' => array(':/[abc]+/i')
-        ));
+        $x = new Parser([
+            'start' => [':/[abc]+/i'],
+        ]);
         $this->assertObject($x->parse('aaa'));
         $this->assertObject($x->parse('abc'));
         $this->assertObject($x->parse('cAB'));
         $this->assertObject($x->parse('ABc'));
         $this->assertFalse($x->parse('ccXB'));
 
-        $x = new Parser(array(
-            'start' => array(array(':/a*/', ':/s?/', 'c'))
-        ));
+        $x = new Parser([
+            'start' => [[':/a*/', ':/s?/', 'c']],
+        ]);
         $this->assertObject($x->parse('aaac'));
         $this->assertObject($x->parse('aaasc'));
         $this->assertObject($x->parse('sc'));
         $this->assertObject($x->parse('c'));
 
-        $x = new Parser(array(
-            'start' => array(array(':ab', ':/(?<=ab)[ba]+/')),
-            'ab' => array('', array('a', ':ab'), array('b', ':ab'))
-        ));
+        $x = new Parser([
+            'start' => [[':ab', ':/(?<=ab)[ba]+/']],
+            'ab' => ['', ['a', ':ab'], ['b', ':ab']],
+        ]);
         $this->assertEquals('bbaab', (string)$x->parse('bbaabaa')->getSubnode(0));
         $this->assertEquals('aa', (string)$x->parse('bbaabaa')->getSubnode(1));
         $this->assertFalse($x->parse('baaa'));
@@ -356,39 +356,39 @@ class ParserTest extends TestCase
 
     public function testIgnoreWhitespacesOption()
     {
-        $on = new Parser(array(
-            'start' => array(array('x', ':start'), ''),
-        ), array('ignoreWhitespaces' => true));
+        $on = new Parser([
+            'start' => [['x', ':start'], ''],
+        ], ['ignoreWhitespaces' => true]);
 
-        $off = new Parser(array(
-            'start' => array(array(':animal', ':start'), ':animal'),
-            'animal' => array('dog', 'cat', 'cow', 'rat')
-        ), array('ignoreWhitespaces' => false));
+        $off = new Parser([
+            'start' => [[':animal', ':start'], ':animal'],
+            'animal' => ['dog', 'cat', 'cow', 'rat'],
+        ], ['ignoreWhitespaces' => false]);
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf('x', "  \n   "),
-            new Branch('start', 1, array(
-                new Leaf('')
-            ))
-        ), ' '), $on->parse(" x  \n   "));
+            new Branch('start', 1, [
+                new Leaf(''),
+            ]),
+        ], ' '), $on->parse(" x  \n   "));
 
         $this->assertFalse($off->parse(" x  \n   "));
 
-        $this->assertEquals(new Root('start', 0, array(
+        $this->assertEquals(new Root('start', 0, [
             new Leaf('x', '  '),
-            new Branch('start', 0, array(
+            new Branch('start', 0, [
                 new Leaf('x', "  \n   "),
-                new Branch('start', 1, array(
-                    new Leaf('')
-                ))
-            ))
-        )), $on->parse("x  x  \n   "));
+                new Branch('start', 1, [
+                    new Leaf(''),
+                ]),
+            ]),
+        ]), $on->parse("x  x  \n   "));
 
         $this->assertFalse($off->parse("x  x  \n   "));
 
-        $this->assertEquals(new Root('start', 1, array(
+        $this->assertEquals(new Root('start', 1, [
             new Leaf('', ''),
-        ), ' '), $on->parse(" "));
+        ], ' '), $on->parse(" "));
 
         $this->assertFalse($off->parse(" "));
     }
@@ -448,13 +448,13 @@ class ParserTest extends TestCase
         $x = new Parser('start:a => "a"
                             :b => "b".');
 
-        $this->assertEquals(new Root('start', 'a', array(
-            new Leaf('a')
-        )), $x->parse('a'));
+        $this->assertEquals(new Root('start', 'a', [
+            new Leaf('a'),
+        ]), $x->parse('a'));
 
-        $this->assertEquals(new Root('start', 'b', array(
-            new Leaf('b')
-        )), $x->parse('b'));
+        $this->assertEquals(new Root('start', 'b', [
+            new Leaf('b'),
+        ]), $x->parse('b'));
     }
 
     public function testStringGrammarBNFStyle()
@@ -462,41 +462,41 @@ class ParserTest extends TestCase
         $x = new Parser('start:a:= "a"
                               :b:= /b/.');
 
-        $this->assertEquals(new Root('start', 'a', array(
-            new Leaf('a')
-        )), $x->parse('a'));
+        $this->assertEquals(new Root('start', 'a', [
+            new Leaf('a'),
+        ]), $x->parse('a'));
 
-        $this->assertEquals(new Root('start', 'b', array(
-            new Leaf('b')
-        )), $x->parse('b'));
+        $this->assertEquals(new Root('start', 'b', [
+            new Leaf('b'),
+        ]), $x->parse('b'));
     }
 
     public function testStringGrammarIgnoreWhitespacesOption()
     {
-        $on = new Parser('start :=> "abc".', array('ignoreWhitespaces' => true));
-        $off = new Parser('start :=> "abc".', array('ignoreWhitespaces' => false));
+        $on = new Parser('start :=> "abc".', ['ignoreWhitespaces' => true]);
+        $off = new Parser('start :=> "abc".', ['ignoreWhitespaces' => false]);
         $this->assertObject($on->parse('abc'));
         $this->assertObject($off->parse('abc'));
         $this->assertObject($on->parse(' abc '));
         $this->assertFalse($off->parse(' abc '));
 
-        $on = new Parser('start :=> /abc/ .', array('ignoreWhitespaces' => true));
-        $off = new Parser('start :=> /abc/ .', array('ignoreWhitespaces' => false));
+        $on = new Parser('start :=> /abc/ .', ['ignoreWhitespaces' => true]);
+        $off = new Parser('start :=> /abc/ .', ['ignoreWhitespaces' => false]);
         $this->assertObject($on->parse('abc'));
         $this->assertObject($off->parse('abc'));
         $this->assertObject($on->parse(' abc '));
         $this->assertFalse($off->parse(' abc '));
 
 
-        $on = new Parser('start :=> string.', array('ignoreWhitespaces' => true));
-        $off = new Parser('start :=> string.', array('ignoreWhitespaces' => false));
+        $on = new Parser('start :=> string.', ['ignoreWhitespaces' => true]);
+        $off = new Parser('start :=> string.', ['ignoreWhitespaces' => false]);
         $this->assertObject($on->parse('"a"'));
         $this->assertObject($off->parse('"a"'));
         $this->assertObject($on->parse(' "a" '));
         $this->assertFalse($off->parse(' "a" '));
 
-        $on = new Parser('start :=> "abc" x y /z/. x :=> "c". y :=> /y/ .', array('ignoreWhitespaces' => true));
-        $off = new Parser('start :=> "abc" x y /z/. x :=> "c". y :=> /y/ .', array('ignoreWhitespaces' => false));
+        $on = new Parser('start :=> "abc" x y /z/. x :=> "c". y :=> /y/ .', ['ignoreWhitespaces' => true]);
+        $off = new Parser('start :=> "abc" x y /z/. x :=> "c". y :=> /y/ .', ['ignoreWhitespaces' => false]);
         $this->assertObject($on->parse('abccyz'));
         $this->assertObject($off->parse('abccyz'));
         $this->assertObject($on->parse(' abc c y z '));
@@ -507,7 +507,7 @@ class ParserTest extends TestCase
 
     public function testToStringWithIgnoreWhitespaces()
     {
-        $x = new Parser('start :=> "ab" "cd" .', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> "ab" "cd" .', ['ignoreWhitespaces' => true]);
 
         $this->assertEquals("abcd", $x->parse("ab   cd")->toString());
         $this->assertEquals("ab   cd",
@@ -521,7 +521,7 @@ class ParserTest extends TestCase
         $this->assertEquals("ab\ncd",
             $x->parse("ab \n cd ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
 
-        $x = new Parser('start :=> /ab/ /cd/ .', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> /ab/ /cd/ .', ['ignoreWhitespaces' => true]);
 
         $this->assertEquals("abcd", $x->parse("ab   cd")->toString());
         $this->assertEquals("ab   cd",
@@ -535,17 +535,17 @@ class ParserTest extends TestCase
         $this->assertEquals("ab\ncd",
             $x->parse("ab \n cd ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_REDUCED_WHITESPACES));
 
-        $x = new Parser('start :=> /a/ /b/ .', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> /a/ /b/ .', ['ignoreWhitespaces' => true]);
         $this->assertEquals("ab", $x->parse("a   b")->toString());
         $this->assertEquals("a   \nb",
             $x->parse("a   \nb")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
 
-        $x = new Parser('start :=> string .', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> string .', ['ignoreWhitespaces' => true]);
         $this->assertEquals("'abc'", $x->parse("'abc'  ")->toString());
         $this->assertEquals("'abc'  ",
             $x->parse("'abc'  ")->toString(\ParserGenerator\SyntaxTreeNode\Base::TO_STRING_ORIGINAL));
 
-        $x = new Parser('start :=> /ab/ /cd/ .', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> /ab/ /cd/ .', ['ignoreWhitespaces' => true]);
 
         $this->assertEquals("abcd", $x->parse(" ab   cd")->toString());
         $this->assertEquals(" ab   cd",
@@ -557,7 +557,7 @@ class ParserTest extends TestCase
     public function testStringGrammarWhitespaceCharacters()
     {
 
-        $x = new Parser('start :=> "a" \s "b" .', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> "a" \s "b" .', ['ignoreWhitespaces' => true]);
         $this->assertFalse($x->parse('ab'));
         $this->assertFalse($x->parse('ab '));
         $this->assertFalse($x->parse(' ab'));
@@ -565,7 +565,7 @@ class ParserTest extends TestCase
         $this->assertObject($x->parse("a\nb"));
         $this->assertObject($x->parse("a   b"));
 
-        $x = new Parser('start :=> "a" space "b" .', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> "a" space "b" .', ['ignoreWhitespaces' => true]);
         $this->assertFalse($x->parse('ab'));
         $this->assertFalse($x->parse('ab '));
         $this->assertFalse($x->parse(' ab'));
@@ -573,7 +573,7 @@ class ParserTest extends TestCase
         $this->assertFalse($x->parse("a\nb"));
         $this->assertObject($x->parse("a  \nb"));
 
-        $x = new Parser('start :=> "a" !space "b" .', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> "a" !space "b" .', ['ignoreWhitespaces' => true]);
         $this->assertObject($x->parse('ab'));
         $this->assertObject($x->parse('ab '));
         $this->assertObject($x->parse(' ab'));
@@ -581,7 +581,7 @@ class ParserTest extends TestCase
         $this->assertObject($x->parse("a\nb"));
         $this->assertFalse($x->parse("a  \nb"));
 
-        $x = new Parser('start :=> "a" !\s "b" .', array('ignoreWhitespaces' => true));
+        $x = new Parser('start :=> "a" !\s "b" .', ['ignoreWhitespaces' => true]);
         $this->assertObject($x->parse('ab'));
         $this->assertObject($x->parse('ab '));
         $this->assertObject($x->parse(' ab'));
@@ -592,7 +592,7 @@ class ParserTest extends TestCase
 
     public function testCaseInsesitivity()
     {
-        $on = new Parser('start :=> "a" /b/ .', array('caseInsensitive' => true));
+        $on = new Parser('start :=> "a" /b/ .', ['caseInsensitive' => true]);
         $off = new Parser('start :=> "a" /b/ .'); //caseInsensitivity is off by default
 
         $this->assertObject($on->parse('ab'));
@@ -610,7 +610,7 @@ class ParserTest extends TestCase
         $this->assertObject($on->parse('AB'));
         $this->assertFalse($off->parse('AB'));
 
-        $x = new Parser('start :=> /a/ /b/i .', array('caseInsensitive' => true));
+        $x = new Parser('start :=> /a/ /b/i .', ['caseInsensitive' => true]);
         $this->assertObject($x->parse('ab'));
         $this->assertObject($x->parse('AB'));
     }
@@ -641,7 +641,7 @@ class ParserTest extends TestCase
     public function testComments()
     {
         $nodeDump = function ($parser) {
-            $result = array();
+            $result = [];
             $parser->iterateOverNodes(function ($node) use (&$result) {
                 $explodedClassName = explode('\\',
                     get_class(\ParserGenerator\GrammarNode\Decorator::undecorate($node)));
@@ -653,31 +653,31 @@ class ParserTest extends TestCase
         };
 
         $x = new Parser('start :=> /* some comments */ "a"');
-        $this->assertArrayElementsEquals(array('Branch[start]', 'Text["a"]'), $nodeDump($x));
+        $this->assertArrayElementsEquals(['Branch[start]', 'Text["a"]'], $nodeDump($x));
 
         $x = new Parser('start :=> /** "commented" /c*/ **/ "a"');
-        $this->assertArrayElementsEquals(array('Branch[start]', 'Text["a"]'), $nodeDump($x));
+        $this->assertArrayElementsEquals(['Branch[start]', 'Text["a"]'], $nodeDump($x));
 
         $x = new Parser('start :=> "a"
                          /** some comment here
                           *  multi line comment
                           **/
                                :=> "b".');
-        $this->assertArrayElementsEquals(array('Branch[start]', 'Text["a"]', 'Text["b"]'), $nodeDump($x));
+        $this->assertArrayElementsEquals(['Branch[start]', 'Text["a"]', 'Text["b"]'], $nodeDump($x));
 
         $x = new Parser('start :=> b "a".
                          /** some comment here
                           *  multi line comment
                           **/
                           b    :=> "b".');
-        $this->assertArrayElementsEquals(array('Branch[start]', 'Branch[b]', 'Text["a"]', 'Text["b"]'), $nodeDump($x));
+        $this->assertArrayElementsEquals(['Branch[start]', 'Branch[b]', 'Text["a"]', 'Text["b"]'], $nodeDump($x));
 
         $x = new Parser('/* comment here */
                          start /* comment here */ :=> "a" /* comment here */. /* comment here */');
-        $this->assertArrayElementsEquals(array('Branch[start]', 'Text["a"]'), $nodeDump($x));
+        $this->assertArrayElementsEquals(['Branch[start]', 'Text["a"]'], $nodeDump($x));
 
         $x = new Parser('start :=> "a" /** "b" */ "c" **/ /** "d" /* "e" */ "f" **/');
-        $this->assertArrayElementsEquals(array('Branch[start]', 'Text["a"]'), $nodeDump($x));
+        $this->assertArrayElementsEquals(['Branch[start]', 'Text["a"]'], $nodeDump($x));
     }
 
     /**

--- a/tests/RegexUtilTest.php
+++ b/tests/RegexUtilTest.php
@@ -47,7 +47,7 @@ class RegexUtilTest extends TestCase
 
     protected function assertCanStart($chars, $regex)
     {
-        $assocCharacters = array();
+        $assocCharacters = [];
         foreach ($chars as $char) {
             $assocCharacters[$char] = true;
         }
@@ -57,28 +57,28 @@ class RegexUtilTest extends TestCase
 
     public function testGetStartCharacters()
     {
-        $this->assertCanStart(array('a'), '/a/');
-        $this->assertCanStart(array('a'), '/ab/');
-        $this->assertCanStart(array('a'), '/a+b/');
-        $this->assertCanStart(array('a', 'b'), '/a*b/');
-        $this->assertCanStart(array('a', 'b'), '/a?b/');
-        $this->assertCanStart(array('a'), '/a+?b/');
-        $this->assertCanStart(array('a', 'b'), '/(a|b)/');
-        $this->assertCanStart(array('a', 'c'), '/(ab|c)/');
-        $this->assertCanStart(array('a', 'b', 'c', 'd', 'e'), '/a?b?c?d?efg/');
-        $this->assertCanStart(array('a', 'b', 'c'), '/(a|b?)c/');
-        $this->assertCanStart(array('a', 'b', 'c'), '/(a|b)?c/');
-        $this->assertCanStart(array('a', 'b'), '/a{0,3}b/');
-        $this->assertCanStart(array('a'), '/a{1,3}b/');
-        $this->assertCanStart(array('a', 'b', 'c'), '/[abc]/');
-        $this->assertCanStart(array('a', 'b', 'c', 'd'), '/[a-d]/');
-        $this->assertCanStart(array('h', 'a', 'b', 'c'), '/[ha-c]/');
-        $this->assertCanStart(array('-', 'a', 'b', 'c'), '/[-a-c]/');
-        $this->assertCanStart(array('a', 'b', 'c', '1', '2', '3'), '/[a-c1-3]/');
-        $this->assertCanStart(array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9'), '/\\d/');
-        $this->assertCanStart(array('['), '/\\[/');
-        $this->assertCanStart(array("\n", "\r", " ", "\t"), '/\\s/');
-        $this->assertCanStart(array("\n", "\r", " ", "\t", "j"), '/[\\sj]/');
+        $this->assertCanStart(['a'], '/a/');
+        $this->assertCanStart(['a'], '/ab/');
+        $this->assertCanStart(['a'], '/a+b/');
+        $this->assertCanStart(['a', 'b'], '/a*b/');
+        $this->assertCanStart(['a', 'b'], '/a?b/');
+        $this->assertCanStart(['a'], '/a+?b/');
+        $this->assertCanStart(['a', 'b'], '/(a|b)/');
+        $this->assertCanStart(['a', 'c'], '/(ab|c)/');
+        $this->assertCanStart(['a', 'b', 'c', 'd', 'e'], '/a?b?c?d?efg/');
+        $this->assertCanStart(['a', 'b', 'c'], '/(a|b?)c/');
+        $this->assertCanStart(['a', 'b', 'c'], '/(a|b)?c/');
+        $this->assertCanStart(['a', 'b'], '/a{0,3}b/');
+        $this->assertCanStart(['a'], '/a{1,3}b/');
+        $this->assertCanStart(['a', 'b', 'c'], '/[abc]/');
+        $this->assertCanStart(['a', 'b', 'c', 'd'], '/[a-d]/');
+        $this->assertCanStart(['h', 'a', 'b', 'c'], '/[ha-c]/');
+        $this->assertCanStart(['-', 'a', 'b', 'c'], '/[-a-c]/');
+        $this->assertCanStart(['a', 'b', 'c', '1', '2', '3'], '/[a-c1-3]/');
+        $this->assertCanStart(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'], '/\\d/');
+        $this->assertCanStart(['['], '/\\[/');
+        $this->assertCanStart(["\n", "\r", " ", "\t"], '/\\s/');
+        $this->assertCanStart(["\n", "\r", " ", "\t", "j"], '/[\\sj]/');
         $this->assertEquals(255,
             count(\ParserGenerator\RegexUtil::getInstance()->getStartCharacters('/./'))); //256 - 1 cause \n is out
     }
@@ -107,19 +107,19 @@ class RegexUtilTest extends TestCase
     public function testRegexGenarateString()
     {
         srand(10);
-        $this->checkStringGenerate('/a/', array('a'));
-        $this->checkStringGenerate('/asd/', array('asd'));
-        $this->checkStringGenerate('/(a|b|c)/', array('a', 'b', 'c'));
-        $this->checkStringGenerate('/a?/', array('a', ''));
-        $this->checkStringGenerate('/a?b?/', array('a', 'b', 'ab', ''));
-        $this->checkStringGenerate('/(a|b|c)?/', array('a', 'b', 'c', ''));
-        $this->checkStringGenerate('/a*/', array('', 'a', 'aa', 'aaa'), 3);
-        $this->checkStringGenerate('/a+/', array('a', 'aa', 'aaa'), 3);
-        $this->checkStringGenerate('/a{2}/', array('aa'));
-        $this->checkStringGenerate('/a{2,3}/', array('aa', 'aaa'));
-        $this->checkStringGenerate('/(a|(c|de)?f)/', array('a', 'cf', 'def', 'f'));
-        $this->checkStringGenerate('/[abc]/', array('a', 'b', 'c'));
-        $this->checkStringGenerate('/[a-dz]/', array('a', 'b', 'c', 'd', 'z'));
-        $this->checkStringGenerate('/\d/', array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9'));
+        $this->checkStringGenerate('/a/', ['a']);
+        $this->checkStringGenerate('/asd/', ['asd']);
+        $this->checkStringGenerate('/(a|b|c)/', ['a', 'b', 'c']);
+        $this->checkStringGenerate('/a?/', ['a', '']);
+        $this->checkStringGenerate('/a?b?/', ['a', 'b', 'ab', '']);
+        $this->checkStringGenerate('/(a|b|c)?/', ['a', 'b', 'c', '']);
+        $this->checkStringGenerate('/a*/', ['', 'a', 'aa', 'aaa'], 3);
+        $this->checkStringGenerate('/a+/', ['a', 'aa', 'aaa'], 3);
+        $this->checkStringGenerate('/a{2}/', ['aa']);
+        $this->checkStringGenerate('/a{2,3}/', ['aa', 'aaa']);
+        $this->checkStringGenerate('/(a|(c|de)?f)/', ['a', 'cf', 'def', 'f']);
+        $this->checkStringGenerate('/[abc]/', ['a', 'b', 'c']);
+        $this->checkStringGenerate('/[a-dz]/', ['a', 'b', 'c', 'd', 'z']);
+        $this->checkStringGenerate('/\d/', ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
     }
 }


### PR DESCRIPTION
- no functional changes
- tried to make sure to not have other code changes
- also added a `,` after the last entry of an array => less noise in diffs when new entries are added

(I changed this in PhpStorm and just reformatted the whole code base => tests ✅)

Depending on merge order with the other PRs, there might be conflicts. Just let me know, will take care of it.