### PR TITLE
Make all possible options always present

### DIFF
--- a/src/Extension/Choice.php
+++ b/src/Extension/Choice.php
@@ -33,7 +33,7 @@ class Choice extends \ParserGenerator\Extension\SequenceItem
         $choices[] = $this->buildInternalSequence($grammar, $sequenceNode->getSubnode(0), $grammarParser, $options);;
 
         $node = new \ParserGenerator\GrammarNode\Choice($choices);
-        if (isset($options['parser'])) {
+        if ($options['parser']) {
             $node->setParser($options['parser']);
         }
 

--- a/src/Extension/Choice.php
+++ b/src/Extension/Choice.php
@@ -33,9 +33,7 @@ class Choice extends \ParserGenerator\Extension\SequenceItem
         $choices[] = $this->buildInternalSequence($grammar, $sequenceNode->getSubnode(0), $grammarParser, $options);;
 
         $node = new \ParserGenerator\GrammarNode\Choice($choices);
-        if ($options['parser']) {
-            $node->setParser($options['parser']);
-        }
+        $node->setParser($options['parser']);
 
         //$grammar[$node->getTmpNodeName()] = $node;
 

--- a/src/Extension/Integer.php
+++ b/src/Extension/Integer.php
@@ -75,7 +75,7 @@ class Integer extends \ParserGenerator\Extension\SequenceItem
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
         $numericOptions = [];
-        $numericOptions['eatWhiteChars'] = !empty($options['ignoreWhitespaces']);
+        $numericOptions['eatWhiteChars'] = $options['ignoreWhitespaces'];
 
         $item = $sequenceItem->getSubnode(0);
         $min = $item->getSubnode(0);

--- a/src/Extension/Regex.php
+++ b/src/Extension/Regex.php
@@ -11,7 +11,7 @@ class Regex extends \ParserGenerator\Extension\SequenceItem
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
-        return new \ParserGenerator\GrammarNode\Regex((string)$sequenceItem, !empty($options['ignoreWhitespaces']),
-            !empty($options['caseInsensitive']));
+        return new \ParserGenerator\GrammarNode\Regex((string)$sequenceItem, $options['ignoreWhitespaces'],
+            $options['caseInsensitive']);
     }
 }

--- a/src/Extension/Series.php
+++ b/src/Extension/Series.php
@@ -38,9 +38,7 @@ class Series extends \ParserGenerator\Extension\SequenceItem
                 $greedy = in_array($operator, ['**', '++']) || $forceGreedy;
                 $node = new \ParserGenerator\GrammarNode\Series($main, $separator,
                     in_array($operator, ['*', '**']), $greedy);
-                if ($options['parser']) {
-                    $node->setParser($options['parser']);
-                }
+                $node->setParser($options['parser']);
 
                 return $node;
             case '??':
@@ -49,9 +47,7 @@ class Series extends \ParserGenerator\Extension\SequenceItem
                 $choices = ($operator == '??' || $forceGreedy) ? [$main, $empty] : [$empty, $main];
                 $node = new \ParserGenerator\GrammarNode\Choice($choices);
 
-                if ($options['parser']) {
-                    $node->setParser($options['parser']);
-                }
+                $node->setParser($options['parser']);
 
                 return $node;
         }

--- a/src/Extension/Series.php
+++ b/src/Extension/Series.php
@@ -22,13 +22,13 @@ class Series extends \ParserGenerator\Extension\SequenceItem
         $main = $grammarParser->buildSequenceItem($grammar, $sequenceItem->getSubnode(0), $options);
         if ($sequenceItem->getSubnode(4)) {
             $separator = $grammarParser->buildSequenceItem($grammar, $sequenceItem->getSubnode(4), $options);
-            if (!empty($options['trackError'])) {
+            if ($options['trackError']) {
                 $separator = new \ParserGenerator\GrammarNode\ErrorTrackDecorator($separator);
             }
         } else {
             $separator = null;
         }
-        $forceGreedy = isset($options['defaultBranchType']) && $options['defaultBranchType'] == BranchFactory::PEG;
+        $forceGreedy = $options['defaultBranchType'] === BranchFactory::PEG;
         $operator = (string)$sequenceItem->getSubnode(2);
         switch ($operator) {
             case '++':
@@ -38,7 +38,7 @@ class Series extends \ParserGenerator\Extension\SequenceItem
                 $greedy = in_array($operator, ['**', '++']) || $forceGreedy;
                 $node = new \ParserGenerator\GrammarNode\Series($main, $separator,
                     in_array($operator, ['*', '**']), $greedy);
-                if (isset($options['parser'])) {
+                if ($options['parser']) {
                     $node->setParser($options['parser']);
                 }
 
@@ -49,7 +49,7 @@ class Series extends \ParserGenerator\Extension\SequenceItem
                 $choices = ($operator == '??' || $forceGreedy) ? [$main, $empty] : [$empty, $main];
                 $node = new \ParserGenerator\GrammarNode\Choice($choices);
 
-                if (isset($options['parser'])) {
+                if ($options['parser']) {
                     $node->setParser($options['parser']);
                 }
 

--- a/src/Extension/StringObject.php
+++ b/src/Extension/StringObject.php
@@ -18,19 +18,16 @@ class StringObject extends \ParserGenerator\Extension\SequenceItem
 
         switch ($type) {
             case "default":
-                return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']),
-                    ["'", '"']);
+                return new \ParserGenerator\GrammarNode\PredefinedString($options['ignoreWhitespaces'], ["'", '"']);
 
             case "apostrophe":
-                return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']),
-                    ["'"]);
+                return new \ParserGenerator\GrammarNode\PredefinedString($options['ignoreWhitespaces'], ["'"]);
 
             case "quotation":
-                return new \ParserGenerator\GrammarNode\PredefinedString(!empty($options['ignoreWhitespaces']),
-                    ['"']);
+                return new \ParserGenerator\GrammarNode\PredefinedString($options['ignoreWhitespaces'], ['"']);
 
             case "simple":
-                return new \ParserGenerator\GrammarNode\PredefinedSimpleString(!empty($options['ignoreWhitespaces']));
+                return new \ParserGenerator\GrammarNode\PredefinedSimpleString($options['ignoreWhitespaces']);
         }
     }
 }

--- a/src/Extension/TextNode.php
+++ b/src/Extension/TextNode.php
@@ -11,14 +11,15 @@ class TextNode extends \ParserGenerator\Extension\SequenceItem
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
-        if (!empty($options['caseInsensitive'])) {
+        if ($options['caseInsensitive']) {
             $regex = \ParserGenerator\RegexUtil::buildRegexFromString((string)$sequenceItem->getSubnode(0)->getValue());
-            return new \ParserGenerator\GrammarNode\Regex($regex, !empty($options['ignoreWhitespaces']),
-                !empty($options['caseInsensitive']));
-        } elseif (empty($options['ignoreWhitespaces'])) {
-            return new \ParserGenerator\GrammarNode\Text($sequenceItem->getSubnode(0)->getValue());
-        } else {
-            return new \ParserGenerator\GrammarNode\TextS($sequenceItem->getSubnode(0)->getValue());
+            return new \ParserGenerator\GrammarNode\Regex($regex, $options['ignoreWhitespaces'], $options['caseInsensitive']);
         }
+
+        if (!$options['ignoreWhitespaces']) {
+            return new \ParserGenerator\GrammarNode\Text($sequenceItem->getSubnode(0)->getValue());
+        }
+
+        return new \ParserGenerator\GrammarNode\TextS($sequenceItem->getSubnode(0)->getValue());
     }
 }

--- a/src/Extension/Time.php
+++ b/src/Extension/Time.php
@@ -21,6 +21,6 @@ class Time extends \ParserGenerator\Extension\SequenceItem
 
     protected function _buildSequenceItem(&$grammar, $sequenceItem, $grammarParser, $options)
     {
-        return new LeafTime((string)$sequenceItem->getSubnode(1), !empty($options['ignoreWhitespaces']));
+        return new LeafTime((string)$sequenceItem->getSubnode(1), $options['ignoreWhitespaces']);
     }
 }

--- a/src/Extension/Unorder.php
+++ b/src/Extension/Unorder.php
@@ -34,7 +34,7 @@ class Unorder extends \ParserGenerator\Extension\SequenceItem
         }
 
 
-        if (isset($options['parser'])) {
+        if ($options['parser']) {
             $node->setParser($options['parser']);
         }
 

--- a/src/Extension/Unorder.php
+++ b/src/Extension/Unorder.php
@@ -34,9 +34,7 @@ class Unorder extends \ParserGenerator\Extension\SequenceItem
         }
 
 
-        if ($options['parser']) {
-            $node->setParser($options['parser']);
-        }
+        $node->setParser($options['parser']);
 
         $grammar[$node->getTmpNodeName()] = $node;
 

--- a/src/Extension/WhiteCharactersContext.php
+++ b/src/Extension/WhiteCharactersContext.php
@@ -40,7 +40,7 @@ class WhiteCharactersContext extends \ParserGenerator\Extension\SequenceItem
                 break;
         }
 
-        if (empty($options['ignoreWhitespaces'])) {
+        if (!$options['ignoreWhitespaces']) {
             $node = null;
             switch ($char) {
                 case "\n":

--- a/src/GrammarParser.php
+++ b/src/GrammarParser.php
@@ -125,11 +125,9 @@ class GrammarParser
             }
         }
 
-        if ($options['parser']) {
-            foreach ($grammar as $node) {
-                if ($node instanceof \ParserGenerator\ParserAwareInterface) {
-                    $node->setParser($options['parser']);
-                }
+        foreach ($grammar as $node) {
+            if ($node instanceof \ParserGenerator\ParserAwareInterface) {
+                $node->setParser($options['parser']);
             }
         }
 

--- a/src/GrammarParser.php
+++ b/src/GrammarParser.php
@@ -85,13 +85,11 @@ class GrammarParser
 
         $grammarBranches = $parsedGrammar->findAll('grammarBranch');
 
-        $defaultBranchType = empty($options['defaultBranchType']) ? \ParserGenerator\GrammarNode\BranchFactory::FULL : $options['defaultBranchType'];
-
         foreach ($grammarBranches as $grammarBranch) {
             if ($grammarBranch->getDetailType() === 'standard') {
                 $branchName = (string)$grammarBranch->findFirst('branchName');
                 $branchTypeNodeStr = (string)$grammarBranch->findFirst('branchType');
-                $branchType = $branchTypeNodeStr ? substr($branchTypeNodeStr, 1, -1) : $defaultBranchType;
+                $branchType = $branchTypeNodeStr ? substr($branchTypeNodeStr, 1, -1) : $options['defaultBranchType'];
                 $grammar[$branchName] = \ParserGenerator\GrammarNode\BranchFactory::createBranch($branchType,
                     $branchName);
             } else {
@@ -127,7 +125,7 @@ class GrammarParser
             }
         }
 
-        if (isset($options['parser'])) {
+        if ($options['parser']) {
             foreach ($grammar as $node) {
                 if ($node instanceof \ParserGenerator\ParserAwareInterface) {
                     $node->setParser($options['parser']);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -103,7 +103,6 @@ class Parser
     protected function buildFromString(string $grammar, array $options)
     {
         $this->options = $options;
-        $options['parser'] = $this;
         $this->grammar = GrammarParser::getInstance()->buildGrammar($grammar, $options);
     }
 
@@ -114,6 +113,9 @@ class Parser
     public function __construct($grammar, array $options = [])
     {
         $options += $this->getDefaultOptions();
+
+        // TODO: don't missuse $options to pass around the parser
+        $options['parser'] = $this;
 
         if (is_array($grammar)) {
             $this->buildFromArray($grammar, $options);
@@ -276,7 +278,6 @@ class Parser
             'caseInsensitive' => false,
             'defaultBranchType' => BranchFactory::FULL,
             'ignoreWhitespaces' => false,
-            'parser' => null,
             'trackError' => true,
         ];
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -3,6 +3,7 @@
 namespace ParserGenerator;
 
 use ParserGenerator\GrammarNode\Branch;
+use ParserGenerator\GrammarNode\BranchFactory;
 use ParserGenerator\GrammarNode\BranchInterface;
 use ParserGenerator\GrammarNode\ErrorTrackDecorator;
 use ParserGenerator\GrammarNode\Lookahead;
@@ -101,9 +102,6 @@ class Parser
 
     protected function buildFromString(string $grammar, array $options)
     {
-        if (!isset($options['errorTrack'])) {
-            $options['trackError'] = true;
-        }
         $this->options = $options;
         $options['parser'] = $this;
         $this->grammar = GrammarParser::getInstance()->buildGrammar($grammar, $options);
@@ -115,6 +113,8 @@ class Parser
      */
     public function __construct($grammar, array $options = [])
     {
+        $options += $this->getDefaultOptions();
+
         if (is_array($grammar)) {
             $this->buildFromArray($grammar, $options);
         } else {
@@ -268,5 +268,16 @@ class Parser
         }
 
         return array_values($errorsByHash);
+    }
+
+    public function getDefaultOptions(): array
+    {
+        return [
+            'caseInsensitive' => false,
+            'defaultBranchType' => BranchFactory::FULL,
+            'ignoreWhitespaces' => false,
+            'parser' => null,
+            'trackError' => true,
+        ];
     }
 }


### PR DESCRIPTION
This avoids having all the `isset()`/`empty()` or `!empty()` constructs.

At all places we can always assume all keys are present.