### PR TITLE
Remove reference operator on $grammar

### DIFF
--- a/src/GrammarParser.php
+++ b/src/GrammarParser.php
@@ -199,7 +199,7 @@ class GrammarParser
         $this->parser = new \ParserGenerator\Parser($grammarGrammar);
     }
 
-    public function buildRule(&$grammar, $rule, $options)
+    public function buildRule($grammar, $rule, $options)
     {
         if ($rule->getDetailType() === 'standard') {
             $sequence = [];
@@ -228,7 +228,7 @@ class GrammarParser
         }
     }
 
-    public function buildSequenceItem(&$grammar, $sequenceItem, $options)
+    public function buildSequenceItem($grammar, $sequenceItem, $options)
     {
         $newSequenceItem = null;
         foreach ($this->plugins as $plugin) {


### PR DESCRIPTION
I don't see the code anywhere modifying `$grammar` and expecting the
changes being reflected elsewhere (unless I'm mistaken).

Tests at least don't show any changed behaviour.