### PR TITLE
Refactor grammar parser

### DIFF
--- a/src/GrammarParser.php
+++ b/src/GrammarParser.php
@@ -3,8 +3,12 @@
 namespace ParserGenerator;
 
 use ParserGenerator\Extension\Choice;
+use ParserGenerator\Extension\ExtensionInterface;
 use ParserGenerator\Extension\Integer;
 use ParserGenerator\Extension\ItemRestrictions;
+use ParserGenerator\Extension\ItemRestrictions\Is;
+use ParserGenerator\Extension\ItemRestrictions\ItemRestrictionNot;
+use ParserGenerator\Extension\ItemRestrictions\ItemRestrictionOr;
 use ParserGenerator\Extension\Lookahead;
 use ParserGenerator\Extension\ParametrizedNode;
 use ParserGenerator\Extension\Regex;
@@ -16,20 +20,31 @@ use ParserGenerator\Extension\TextNode;
 use ParserGenerator\Extension\Time;
 use ParserGenerator\Extension\Unorder;
 use ParserGenerator\Extension\WhiteCharactersContext;
+use ParserGenerator\GrammarNode\Branch;
+use ParserGenerator\GrammarNode\BranchFactory;
 use ParserGenerator\GrammarNode\ErrorTrackDecorator;
+use ParserGenerator\GrammarNode\ItemRestrictions as GrammarItemRestrictions;
+use ParserGenerator\GrammarNode\Regex as GrammarRegex;
+use ParserGenerator\GrammarNode\TextS;
 
 class GrammarParser
 {
+    /** @var ExtensionInterface[] */
     static public $defaultPlugins = [];
-    static protected $instance = null;
+    /** @var ExtensionInterface[] */
     protected $plugins = [];
+    /** @var bool */
     protected $parserSchouldBeRefreshed = true;
-    protected $parser = null;
+
+    /** @var GrammarParser */
+    static protected $instance;
+    /** @var Parser */
+    protected $parser;
 
     public function __construct()
     {
         $this->addDefaultPlugins();
-        $this->loadPlugins();
+        $this->addPlugins();
     }
 
     public function addDefaultPlugins()
@@ -51,20 +66,20 @@ class GrammarParser
         static::$defaultPlugins[] = new ParametrizedNode();
     }
 
-    public function loadPlugins()
+    public function addPlugins()
     {
         foreach (self::$defaultPlugins as $plugin) {
             $this->addPlugin($plugin);
         }
     }
 
-    public function addPlugin($plugin)
+    public function addPlugin(ExtensionInterface $plugin)
     {
         $this->plugins[] = $plugin;
         $this->parserSchouldBeRefreshed = true;
     }
 
-    static public function getInstance()
+    static public function getInstance(): GrammarParser
     {
         if (!self::$instance) {
             self::$instance = new self();
@@ -73,7 +88,12 @@ class GrammarParser
         return self::$instance;
     }
 
-    public function buildGrammar($grammarStr, $options = [])
+    /**
+     * @param string $grammarStr
+     * @param array $options
+     * @return Branch[]
+     */
+    public function buildGrammar(string $grammarStr, array $options = []): array
     {
         $grammar = [];
         $parsedGrammar = $this->getParser()->parse($grammarStr);
@@ -90,8 +110,7 @@ class GrammarParser
                 $branchName = (string)$grammarBranch->findFirst('branchName');
                 $branchTypeNodeStr = (string)$grammarBranch->findFirst('branchType');
                 $branchType = $branchTypeNodeStr ? substr($branchTypeNodeStr, 1, -1) : $options['defaultBranchType'];
-                $grammar[$branchName] = \ParserGenerator\GrammarNode\BranchFactory::createBranch($branchType,
-                    $branchName);
+                $grammar[$branchName] = BranchFactory::createBranch($branchType, $branchName);
             } else {
                 foreach ($this->plugins as $plugin) {
                     $grammar = $plugin->createGrammarBranch($grammar, $grammarBranch, $this, $options);
@@ -107,6 +126,7 @@ class GrammarParser
             if ($grammarBranch->getDetailType() === 'standard') {
                 $branchName = (string)$grammarBranch->findFirst('branchName');
                 $rules = [];
+
                 foreach ($grammarBranch->findAll('rule') as $rule) {
                     $buildRule = $this->buildRule($grammar, $rule, $options);
                     $ruleName = (string)$rule->findFirst('ruleName');
@@ -126,7 +146,7 @@ class GrammarParser
         }
 
         foreach ($grammar as $node) {
-            if ($node instanceof \ParserGenerator\ParserAwareInterface) {
+            if ($node instanceof ParserAwareInterface) {
                 $node->setParser($options['parser']);
             }
         }
@@ -134,35 +154,34 @@ class GrammarParser
         return $grammar;
     }
 
-    public function getParser()
+    public function getParser(): Parser
     {
         if ($this->parserSchouldBeRefreshed) {
-            $this->generateNewParser();
+            $this->parser = $this->generateNewParser();
             $this->parserSchouldBeRefreshed = false;
         }
 
         return $this->parser;
     }
 
-    protected function buildBranchNameNode()
+    protected function buildBranchNameNode(): GrammarItemRestrictions
     {
         $restrictedWords = ['or', 'and', 'contain', 'is', 'text', 'string'];
 
         $restrictedWordsGrammarNode = [];
         foreach ($restrictedWords as $restrictedWord) {
-            $restrictedWordsGrammarNode[] = new \ParserGenerator\Extension\ItemRestrictions\Is(new \ParserGenerator\GrammarNode\TextS($restrictedWord));
+            $restrictedWordsGrammarNode[] = new Is(new TextS($restrictedWord));
         }
 
-        $q = new \ParserGenerator\GrammarNode\ItemRestrictions(
-            new \ParserGenerator\GrammarNode\Regex('/[A-Za-z_][0-9A-Za-z_]*/', true),
-            new \ParserGenerator\Extension\ItemRestrictions\ItemRestrictionNot(
-                new \ParserGenerator\Extension\ItemRestrictions\ItemRestrictionOr($restrictedWordsGrammarNode)
+        return
+            new GrammarItemRestrictions(
+                new GrammarRegex('/[A-Za-z_][0-9A-Za-z_]*/', true),
+                new ItemRestrictionNot(
+                    new ItemRestrictionOr($restrictedWordsGrammarNode)
             ));
-
-        return $q;
     }
 
-    protected function generateNewParser()
+    protected function generateNewParser(): Parser
     {
         $stdGrammarGrammar = [
             'start' => [[':grammarBranches']],
@@ -196,13 +215,14 @@ class GrammarParser
         $grammarGrammar['branchName'] = [[$this->buildBranchNameNode()]];
         $grammarGrammar['sequenceItem']['branch'] = ':branchName';
 
-        $this->parser = new \ParserGenerator\Parser($grammarGrammar);
+        return new Parser($grammarGrammar);
     }
 
     public function buildRule($grammar, $rule, $options)
     {
         if ($rule->getDetailType() === 'standard') {
             $sequence = [];
+
             foreach ($rule->findAll('sequenceItem') as $sequenceItem) {
                 $sequenceItemNode = $this->buildSequenceItem($grammar, $sequenceItem, $options);
                 if (count($sequence)) {
@@ -210,46 +230,41 @@ class GrammarParser
                 }
                 $sequence[] = $sequenceItemNode;
             }
+
             return $sequence;
-        } else {
-            $newSequence = null;
+        }
 
-            foreach ($this->plugins as $plugin) {
-                if ($newSequence = $plugin->buildSequence($grammar, $rule, $this, $options)) {
-                    break;
-                }
-            }
+        $newSequence = null;
 
-            if ($newSequence) {
+        foreach ($this->plugins as $plugin) {
+            if ($newSequence = $plugin->buildSequence($grammar, $rule, $this, $options)) {
                 return $newSequence;
-            } else {
-                throw new Exception('Rule type [' . $rule->getDetailType() . '] added but not supported');
             }
         }
+
+        throw new Exception('Rule type [' . $rule->getDetailType() . '] added but not supported');
     }
 
     public function buildSequenceItem($grammar, $sequenceItem, $options)
     {
         $newSequenceItem = null;
+
         foreach ($this->plugins as $plugin) {
             if ($newSequenceItem = $plugin->buildSequenceItem($grammar, $sequenceItem, $this, $options)) {
-                break;
+                return $newSequenceItem;
             }
         }
 
-        if ($newSequenceItem) {
-            return $newSequenceItem;
-        } else {
-            if ($sequenceItem->getDetailType() === 'branch') {
-                $branchName = (string)$sequenceItem;
-                if (empty($grammar[$branchName])) {
-                    throw new Exception("Grammar definition error: Undefined branch [$branchName]");
-                }
+        if ($sequenceItem->getDetailType() === 'branch') {
+            $branchName = (string)$sequenceItem;
 
-                return $grammar[$branchName];
-            } else {
-                throw new Exception('Sequence item type [' . $sequenceItem->getDetailType() . '] added but not supported');
+            if (empty($grammar[$branchName])) {
+                throw new Exception("Grammar definition error: Undefined branch [$branchName]");
             }
+
+            return $grammar[$branchName];
         }
+
+        throw new Exception('Sequence item type [' . $sequenceItem->getDetailType() . '] added but not supported');
     }
 }


### PR DESCRIPTION
This is the same idea as #30:
- import all classes
- added type declarations were easily possible
- try to un-nest if conditions were possible
- renamed `loadPlugins` to `addPlugins` (that was my fault, no idea wht I came up with `load`…)
- added liberal whitespace in selected parts to make code less dense and more readable

No functional changes intended.