### PR TITLE
[COMPOSER] Move tests namespace into autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,12 @@
     },
     "autoload": {
         "psr-4": {
-            "ParserGenerator\\Tests\\": "tests/",
             "ParserGenerator\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ParserGenerator\\Tests\\": "tests/"
         }
     },
     "authors": [


### PR DESCRIPTION
It's good practice to separate them so in production autoload-dev isn't
even considered.